### PR TITLE
OPLS Dihedral

### DIFF
--- a/libhoomd/computes/OPLSDihedralForceCompute.cc
+++ b/libhoomd/computes/OPLSDihedralForceCompute.cc
@@ -1,0 +1,415 @@
+/*
+Highly Optimized Object-oriented Many-particle Dynamics -- Blue Edition
+(HOOMD-blue) Open Source Software License Copyright 2009-2014 The Regents of
+the University of Michigan All rights reserved.
+
+HOOMD-blue may contain modifications ("Contributions") provided, and to which
+copyright is held, by various Contributors who have granted The Regents of the
+University of Michigan the right to modify and/or distribute such Contributions.
+
+You may redistribute, use, and create derivate works of HOOMD-blue, in source
+and binary forms, provided you abide by the following conditions:
+
+* Redistributions of source code must retain the above copyright notice, this
+list of conditions, and the following disclaimer both in the code and
+prominently in any materials provided with the distribution.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions, and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+* All publications and presentations based on HOOMD-blue, including any reports
+or published results obtained, in whole or in part, with HOOMD-blue, will
+acknowledge its use according to the terms posted at the time of submission on:
+http://codeblue.umich.edu/hoomd-blue/citations.html
+
+* Any electronic documents citing HOOMD-Blue will link to the HOOMD-Blue website:
+http://codeblue.umich.edu/hoomd-blue/
+
+* Apart from the above required attributions, neither the name of the copyright
+holder nor the names of HOOMD-blue's contributors may be used to endorse or
+promote products derived from this software without specific prior written
+permission.
+
+Disclaimer
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND/OR ANY
+WARRANTIES THAT THIS SOFTWARE IS FREE OF INFRINGEMENT ARE DISCLAIMED.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Maintainer: ksil
+
+#ifdef WIN32
+#pragma warning( push )
+#pragma warning( disable : 4244 )
+#endif
+
+#include <boost/python.hpp>
+using namespace boost::python;
+
+#include "OPLSDihedralForceCompute.h"
+
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <cmath>
+
+using namespace std;
+
+// SMALL a relatively small number
+#define SMALL     0.001
+#define SMALLER   0.00001
+
+/*! \file OPLSDihedralForceCompute.cc
+    \brief Contains code for the OPLSDihedralForceCompute class
+*/
+
+/*! \param sysdef System to compute forces on
+    \post Memory is allocated, and forces are zeroed.
+*/
+OPLSDihedralForceCompute::OPLSDihedralForceCompute(boost::shared_ptr<SystemDefinition> sysdef)
+    : ForceCompute(sysdef)
+{
+    m_exec_conf->msg->notice(5) << "Constructing OPLSDihedralForceCompute" << endl;
+
+    // access the dihedral data for later use
+    m_dihedral_data = m_sysdef->getDihedralData();
+
+    // check for some silly errors a user could make
+    if (m_dihedral_data->getNTypes() == 0)
+        {
+        m_exec_conf->msg->error() << "dihedral.opls: No dihedral types specified" << endl;
+        throw runtime_error("Error initializing OPLSDihedralForceCompute");
+        }
+
+    // allocate the parameters
+    GPUArray<Scalar4> params(m_dihedral_data->getNTypes(), exec_conf);
+    m_params.swap(params);
+}
+
+OPLSDihedralForceCompute::~OPLSDihedralForceCompute()
+{
+    m_exec_conf->msg->notice(5) << "Destroying OPLSDihedralForceCompute" << endl;
+}
+
+/*! \param type Type of the dihedral to set parameters for
+    \param k1 Force paramater in OPLS-style dihedral
+    \param k2 Force paramater in OPLS-style dihedral
+    \param k3 Force paramater in OPLS-style dihedral
+    \param k4 Force paramater in OPLS-style dihedral
+
+    Sets the parameters for the potential of an OPLS Dihedral, storing them with the
+    1/2 prefactor.
+*/
+void OPLSDihedralForceCompute::setParams(unsigned int type, Scalar k1, Scalar k2, Scalar k3, Scalar k4)
+{
+    // make sure the type is valid
+    if (type >= m_dihedral_data->getNTypes())
+        {
+        m_exec_conf->msg->error() << "dihedral.opls: Invalid dihedral type specified" << endl;
+        throw runtime_error("Error setting parameters in OPLSDihedralForceCompute");
+        }
+    
+    // set parameters in m_params
+    ArrayHandle<Scalar4> h_params(m_params, access_location::host, access_mode::readwrite);
+    h_params.data[type] = make_scalar4(k1/2.0, k2/2.0, k3/2.0, k4/2.0);
+}
+
+/*! DihedralForceCompute provides
+    - \c dihedral_opls_energy
+*/
+std::vector< std::string > OPLSDihedralForceCompute::getProvidedLogQuantities()
+    {
+    vector<string> list;
+    list.push_back("dihedral_opls_energy");
+    return list;
+    }
+
+/*! \param quantity Name of the quantity to get the log value of
+    \param timestep Current time step of the simulation
+*/
+Scalar OPLSDihedralForceCompute::getLogValue(const std::string& quantity, unsigned int timestep)
+    {
+    if (quantity == string("dihedral_opls_energy"))
+        {
+        compute(timestep);
+        return calcEnergySum();
+        }
+    else
+        {
+        m_exec_conf->msg->error() << "dihedral.opls: " << quantity << " is not a valid log quantity" << endl;
+        throw runtime_error("Error getting log value");
+        }
+    }
+
+/*! Actually perform the force computation
+    \param timestep Current time step
+ */
+void OPLSDihedralForceCompute::computeForces(unsigned int timestep)
+    {
+    if (m_prof) m_prof->push("OPLS Dihedral");
+
+    assert(m_pdata);
+    // access the particle data arrays
+    ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(), access_location::host, access_mode::read);
+    ArrayHandle<unsigned int> h_rtag(m_pdata->getRTags(), access_location::host, access_mode::read);
+
+    // access the force and virial tensor arrays
+    ArrayHandle<Scalar4> h_force(m_force, access_location::host, access_mode::overwrite);
+    ArrayHandle<Scalar> h_virial(m_virial, access_location::host, access_mode::overwrite);
+    
+    // access parameter data
+    ArrayHandle<Scalar4> h_params(m_params, access_location::host, access_mode::read);
+
+    // Zero data for force calculation before computation
+    memset((void*)h_force.data,0,sizeof(Scalar4)*m_force.getNumElements());
+    memset((void*)h_virial.data,0,sizeof(Scalar)*m_virial.getNumElements());
+
+    // there are enough other checks on the input data, but it doesn't hurt to be safe
+    assert(h_force.data);
+    assert(h_virial.data);
+    assert(h_pos.data);
+    assert(h_rtag.data);
+
+    unsigned int virial_pitch = m_virial.getPitch();
+
+    // From LAMMPS OPLS dihedral implementation
+    unsigned int i1,i2,i3,i4,n,dihedral_type;
+    Scalar3 vb1,vb2,vb3,vb2m;
+    Scalar4 f1,f2,f3,f4;
+    Scalar sb1,sb2,sb3,rb1,rb3,c0,b1mag2,b1mag,b2mag2;
+    Scalar b2mag,b3mag2,b3mag,ctmp,r12c1,c1mag,r12c2,e_dihedral;
+    Scalar c2mag,sc1,sc2,s1,s12,c,p,pd,a,a11,a22;
+    Scalar a33,a12,a13,a23,sx2,sy2,sz2;
+    Scalar s2,cx,cy,cz,cmag,dx,phi,si,siinv,sin2;
+    Scalar k1,k2,k3,k4;
+    Scalar dihedral_virial[6];
+    
+    // get a local copy of the simulation box
+    const BoxDim& box = m_pdata->getBox();
+
+    // iterate through each dihedral
+    const unsigned int numDihedrals = (unsigned int)m_dihedral_data->getN();
+    for (n = 0; n < numDihedrals; n++)
+        {
+        // lookup the tag of each of the particles participating in the dihedral
+        const ImproperData::members_t& dihedral = m_dihedral_data->getMembersByIndex(n);
+        assert(dihedral.tag[0] < m_pdata->getNGlobal());
+        assert(dihedral.tag[1] < m_pdata->getNGlobal());
+        assert(dihedral.tag[2] < m_pdata->getNGlobal());
+        assert(dihedral.tag[3] < m_pdata->getNGlobal());
+    
+        // i1 to i4 are the tags
+        i1 = h_rtag.data[dihedral.tag[0]];
+        i2 = h_rtag.data[dihedral.tag[1]];
+        i3 = h_rtag.data[dihedral.tag[2]];
+        i4 = h_rtag.data[dihedral.tag[3]];
+        
+        // throw an error if this angle is incomplete
+        if (i1 == NOT_LOCAL|| i2 == NOT_LOCAL || i3 == NOT_LOCAL || i4 == NOT_LOCAL)
+            {
+            this->m_exec_conf->msg->error() << "dihedral.opls: dihedral " <<
+                dihedral.tag[0] << " " << dihedral.tag[1] << " " << dihedral.tag[2] << " " << dihedral.tag[3]
+                << " incomplete." << endl << endl;
+            throw std::runtime_error("Error in dihedral calculation");
+            }
+        
+        assert(idx_a < m_pdata->getN() + m_pdata->getNGhosts());
+        assert(idx_b < m_pdata->getN() + m_pdata->getNGhosts());
+        assert(idx_c < m_pdata->getN() + m_pdata->getNGhosts());
+        assert(idx_d < m_pdata->getN() + m_pdata->getNGhosts());
+
+        // 1st bond
+
+        vb1.x = h_pos.data[i1].x - h_pos.data[i2].x;
+        vb1.y = h_pos.data[i1].y - h_pos.data[i2].y;
+        vb1.z = h_pos.data[i1].z - h_pos.data[i2].z;
+
+        // 2nd bond
+
+        vb2.x = h_pos.data[i3].x - h_pos.data[i2].x;
+        vb2.y = h_pos.data[i3].y - h_pos.data[i2].y;
+        vb2.z = h_pos.data[i3].z - h_pos.data[i2].z;
+
+        // 3rd bond
+
+        vb3.x = h_pos.data[i4].x - h_pos.data[i3].x;
+        vb3.y = h_pos.data[i4].y - h_pos.data[i3].y;
+        vb3.z = h_pos.data[i4].z - h_pos.data[i3].z;
+        
+        // apply periodic boundary conditions
+        vb1 = box.minImage(vb1);
+        vb2 = box.minImage(vb2);
+        vb3 = box.minImage(vb3);
+        
+        vb2m.x = -vb2.x;
+        vb2m.y = -vb2.y;
+        vb2m.z = -vb2.z;
+        vb2m = box.minImage(vb2m);
+
+        // c0 calculation
+
+        sb1 = 1.0 / (vb1.x*vb1.x + vb1.y*vb1.y + vb1.z*vb1.z);
+        sb2 = 1.0 / (vb2.x*vb2.x + vb2.y*vb2.y + vb2.z*vb2.z);
+        sb3 = 1.0 / (vb3.x*vb3.x + vb3.y*vb3.y + vb3.z*vb3.z);
+
+        rb1 = sqrt(sb1);
+        rb3 = sqrt(sb3);
+
+        c0 = (vb1.x*vb3.x + vb1.y*vb3.y + vb1.z*vb3.z) * rb1*rb3;
+
+        // 1st and 2nd angle
+
+        b1mag2 = vb1.x*vb1.x + vb1.y*vb1.y + vb1.z*vb1.z;
+        b1mag = sqrt(b1mag2);
+        b2mag2 = vb2.x*vb2.x + vb2.y*vb2.y + vb2.z*vb2.z;
+        b2mag = sqrt(b2mag2);
+        b3mag2 = vb3.x*vb3.x + vb3.y*vb3.y + vb3.z*vb3.z;
+        b3mag = sqrt(b3mag2);
+
+        ctmp = vb1.x*vb2.x + vb1.y*vb2.y + vb1.z*vb2.z;
+        r12c1 = 1.0 / (b1mag*b2mag);
+        c1mag = ctmp * r12c1;
+
+        ctmp = vb2m.x*vb3.x + vb2m.y*vb3.y + vb2m.z*vb3.z;
+        r12c2 = 1.0 / (b2mag*b3mag);
+        c2mag = ctmp * r12c2;
+
+        // cos and sin of 2 angles and final c
+
+        sin2 = 1.0 - c1mag*c1mag;
+        if (sin2 < 0.0) sin2 = 0.0;
+        sc1 = sqrt(sin2);
+        if (sc1 < SMALL) sc1 = SMALL;
+        sc1 = 1.0/sc1;
+
+        sin2 = 1.0 - c2mag*c2mag;
+        if (sin2 < 0.0) sin2 = 0.0;
+        sc2 = sqrt(sin2);
+        if (sc2 < SMALL) sc2 = SMALL;
+        sc2 = 1.0/sc2;
+
+        s1 = sc1 * sc1;
+        s2 = sc2 * sc2;
+        s12 = sc1 * sc2;
+        c = (c0 + c1mag*c2mag) * s12;
+
+        cx = vb1.y*vb2.z - vb1.z*vb2.y;
+        cy = vb1.z*vb2.x - vb1.x*vb2.z;
+        cz = vb1.x*vb2.y - vb1.y*vb2.x;
+        cmag = sqrt(cx*cx + cy*cy + cz*cz);
+        dx = (cx*vb3.x + cy*vb3.y + cz*vb3.z)/cmag/b3mag;
+
+        if (c > 1.0) c = 1.0;
+        if (c < -1.0) c = -1.0;
+
+        // force & energy
+        // p = sum (i=1,4) k_i * (1 + (-1)**(i+1)*cos(i*phi) )
+        // pd = dp/dc
+
+        phi = acos(c);
+        if (dx < 0.0) phi *= -1.0;
+        si = sin(phi);
+        if (fabs(si) < SMALLER) si = SMALLER;
+        siinv = 1.0/si;
+        
+        // get values for k1/2 through k4/2
+        // ----- The 1/2 factor is already stored in the parameters --------
+        dihedral_type = m_dihedral_data->getTypeByIndex(n);
+        k1 = h_params.data[dihedral_type].x;
+        k2 = h_params.data[dihedral_type].y;
+        k3 = h_params.data[dihedral_type].z;
+        k4 = h_params.data[dihedral_type].w;
+
+        // the potential energy of the dihedral
+        p = k1*(1.0 + c) + k2*(1.0 - cos(2.0*phi)) + k3*(1.0 + cos(3.0*phi)) + k4*(1.0 - cos(4.0*phi));
+        pd = k1 - 2.0*k2*sin(2.0*phi)*siinv + 3.0*k3*sin(3.0*phi)*siinv - 4.0*k4*sin(4.0*phi)*siinv;
+
+        // Compute 1/4 of energy and assign to each of 4 atoms in the dihedral
+        e_dihedral = 0.25*p;
+
+        a = pd;
+        c = c * a;
+        s12 = s12 * a;
+        a11 = c*sb1*s1;
+        a22 = -sb2 * (2.0*c0*s12 - c*(s1+s2));
+        a33 = c*sb3*s2;
+        a12 = -r12c1 * (c1mag*c*s1 + c2mag*s12);
+        a13 = -rb1*rb3*s12;
+        a23 = r12c2 * (c2mag*c*s2 + c1mag*s12);
+
+        sx2  = a12*vb1.x + a22*vb2.x + a23*vb3.x;
+        sy2  = a12*vb1.y + a22*vb2.y + a23*vb3.y;
+        sz2  = a12*vb1.z + a22*vb2.z + a23*vb3.z;
+
+        f1.x = a11*vb1.x + a12*vb2.x + a13*vb3.x;
+        f1.y = a11*vb1.y + a12*vb2.y + a13*vb3.y;
+        f1.z = a11*vb1.z + a12*vb2.z + a13*vb3.z;
+        f1.w = e_dihedral;
+
+        f2.x = -sx2 - f1.x;
+        f2.y = -sy2 - f1.y;
+        f2.z = -sz2 - f1.z;
+        f2.w = e_dihedral;
+
+        f4.x = a13*vb1.x + a23*vb2.x + a33*vb3.x;
+        f4.y = a13*vb1.y + a23*vb2.y + a33*vb3.y;
+        f4.z = a13*vb1.z + a23*vb2.z + a33*vb3.z;
+        f4.w = e_dihedral;
+
+        f3.x = sx2 - f4.x;
+        f3.y = sy2 - f4.y;
+        f3.z = sz2 - f4.z;
+        f3.w = e_dihedral;
+        
+        // Apply force to each of the 4 atoms
+        h_force.data[i1] = f1;
+        h_force.data[i2] = f2;
+        h_force.data[i3] = f3;
+        h_force.data[i4] = f4;
+        
+        // Compute 1/4 of the virial, 1/4 for each atom in the dihedral
+        // upper triangular version of virial tensor
+        dihedral_virial[0] = 0.25*(vb1.x*f1.x + vb2.x*f3.x + (vb3.x+vb2.x)*f4.x);
+        dihedral_virial[1] = 0.25*(vb1.y*f1.x + vb2.y*f3.x + (vb3.y+vb2.y)*f4.x);
+        dihedral_virial[2] = 0.25*(vb1.z*f1.x + vb2.z*f3.x + (vb3.z+vb2.z)*f4.x);
+        dihedral_virial[3] = 0.25*(vb1.y*f1.y + vb2.y*f3.y + (vb3.y+vb2.y)*f4.y);
+        dihedral_virial[4] = 0.25*(vb1.z*f1.y + vb2.z*f3.y + (vb3.z+vb2.z)*f4.y);
+        dihedral_virial[5] = 0.25*(vb1.z*f1.z + vb2.z*f3.z + (vb3.z+vb2.z)*f4.z);
+        
+        for (int k = 0; k < 6; k++)
+            {
+            h_virial.data[virial_pitch*k+i1]  += dihedral_virial[k];
+            h_virial.data[virial_pitch*k+i2]  += dihedral_virial[k];
+            h_virial.data[virial_pitch*k+i3]  += dihedral_virial[k];
+            h_virial.data[virial_pitch*k+i4]  += dihedral_virial[k];
+            }
+        }
+
+    if (m_prof) m_prof->pop();
+    }
+
+void export_OPLSDihedralForceCompute()
+    {
+    class_<OPLSDihedralForceCompute, boost::shared_ptr<OPLSDihedralForceCompute>, bases<ForceCompute>, boost::noncopyable >
+    ("OPLSDihedralForceCompute", init< boost::shared_ptr<SystemDefinition> >())
+    .def("setParams", &OPLSDihedralForceCompute::setParams)
+    ;
+    }
+
+#ifdef WIN32
+#pragma warning( pop )
+#endif
+
+#undef SMALL
+#undef SMALLER

--- a/libhoomd/computes/OPLSDihedralForceCompute.cc
+++ b/libhoomd/computes/OPLSDihedralForceCompute.cc
@@ -373,10 +373,22 @@ void OPLSDihedralForceCompute::computeForces(unsigned int timestep)
         f3.w = e_dihedral;
         
         // Apply force to each of the 4 atoms
-        h_force.data[i1] = f1;
-        h_force.data[i2] = f2;
-        h_force.data[i3] = f3;
-        h_force.data[i4] = f4;
+        h_force.data[i1].x += f1.x;
+        h_force.data[i1].y += f1.y;
+        h_force.data[i1].z += f1.z;
+        h_force.data[i1].w += f1.w;
+        h_force.data[i2].x += f2.x;
+        h_force.data[i2].y += f2.y;
+        h_force.data[i2].z += f2.z;
+        h_force.data[i2].w += f2.w;
+        h_force.data[i3].x += f3.x;
+        h_force.data[i3].y += f3.y;
+        h_force.data[i3].z += f3.z;
+        h_force.data[i3].w += f3.w;
+        h_force.data[i4].x += f4.x;
+        h_force.data[i4].y += f4.y;
+        h_force.data[i4].z += f4.z;
+        h_force.data[i4].w += f4.w;
         
         // Compute 1/4 of the virial, 1/4 for each atom in the dihedral
         // upper triangular version of virial tensor

--- a/libhoomd/computes/OPLSDihedralForceCompute.h
+++ b/libhoomd/computes/OPLSDihedralForceCompute.h
@@ -1,0 +1,120 @@
+/*
+Highly Optimized Object-oriented Many-particle Dynamics -- Blue Edition
+(HOOMD-blue) Open Source Software License Copyright 2009-2014 The Regents of
+the University of Michigan All rights reserved.
+
+HOOMD-blue may contain modifications ("Contributions") provided, and to which
+copyright is held, by various Contributors who have granted The Regents of the
+University of Michigan the right to modify and/or distribute such Contributions.
+
+You may redistribute, use, and create derivate works of HOOMD-blue, in source
+and binary forms, provided you abide by the following conditions:
+
+* Redistributions of source code must retain the above copyright notice, this
+list of conditions, and the following disclaimer both in the code and
+prominently in any materials provided with the distribution.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions, and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+* All publications and presentations based on HOOMD-blue, including any reports
+or published results obtained, in whole or in part, with HOOMD-blue, will
+acknowledge its use according to the terms posted at the time of submission on:
+http://codeblue.umich.edu/hoomd-blue/citations.html
+
+* Any electronic documents citing HOOMD-Blue will link to the HOOMD-Blue website:
+http://codeblue.umich.edu/hoomd-blue/
+
+* Apart from the above required attributions, neither the name of the copyright
+holder nor the names of HOOMD-blue's contributors may be used to endorse or
+promote products derived from this software without specific prior written
+permission.
+
+Disclaimer
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND/OR ANY
+WARRANTIES THAT THIS SOFTWARE IS FREE OF INFRINGEMENT ARE DISCLAIMED.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Maintainer: ksil
+
+#include <boost/shared_ptr.hpp>
+
+#include "ForceCompute.h"
+#include "BondedGroupData.h"
+
+#include <vector>
+
+/*! \file OPLSDihedralForceCompute.h
+    \brief Declares a class for computing OPLS dihedrals
+*/
+
+#ifdef NVCC
+#error This header cannot be compiled by nvcc
+#endif
+
+#ifndef __OPLSDIHEDRALFORCECOMPUTE_H__
+#define __OPLSDIHEDRALFORCECOMPUTE_H__
+
+//! Computes OPLS dihedral forces on each particle
+/*! OPLS dihedral forces are computed on every particle in the simulation.
+
+    The dihedrals which forces are computed on are accessed from ParticleData::getDihedralData
+    \ingroup computes
+*/
+class OPLSDihedralForceCompute : public ForceCompute
+    {
+    public:
+        //! Constructs the compute
+        OPLSDihedralForceCompute(boost::shared_ptr<SystemDefinition> sysdef);
+
+        //! Destructor
+        virtual ~OPLSDihedralForceCompute();
+
+        //! Set the parameters
+        virtual void setParams(unsigned int type, Scalar k1, Scalar k2, Scalar k3, Scalar k4);
+
+        //! Returns a list of log quantities this compute calculates
+        virtual std::vector< std::string > getProvidedLogQuantities();
+
+        //! Calculates the requested log value and returns it
+        virtual Scalar getLogValue(const std::string& quantity, unsigned int timestep);
+
+        #ifdef ENABLE_MPI
+        //! Get ghost particle fields requested by this pair potential
+        /*! \param timestep Current time step
+        */
+        virtual CommFlags getRequestedCommFlags(unsigned int timestep)
+            {
+            CommFlags flags = CommFlags(0);
+            flags[comm_flag::tag] = 1;
+            flags |= ForceCompute::getRequestedCommFlags(timestep);
+            return flags;
+            }
+        #endif
+
+    protected:
+        GPUArray<Scalar4> m_params;
+
+        //!< Dihedral data to use in computing dihedrals
+        boost::shared_ptr<DihedralData> m_dihedral_data;
+
+        //! Actually compute the forces
+        virtual void computeForces(unsigned int timestep);
+    };
+
+//! Exports the DihedralForceCompute class to python
+void export_OPLSDihedralForceCompute();
+
+#endif

--- a/libhoomd/computes_gpu/OPLSDihedralForceComputeGPU.cc
+++ b/libhoomd/computes_gpu/OPLSDihedralForceComputeGPU.cc
@@ -1,0 +1,138 @@
+/*
+Highly Optimized Object-oriented Many-particle Dynamics -- Blue Edition
+(HOOMD-blue) Open Source Software License Copyright 2009-2014 The Regents of
+the University of Michigan All rights reserved.
+
+HOOMD-blue may contain modifications ("Contributions") provided, and to which
+copyright is held, by various Contributors who have granted The Regents of the
+University of Michigan the right to modify and/or distribute such Contributions.
+
+You may redistribute, use, and create derivate works of HOOMD-blue, in source
+and binary forms, provided you abide by the following conditions:
+
+* Redistributions of source code must retain the above copyright notice, this
+list of conditions, and the following disclaimer both in the code and
+prominently in any materials provided with the distribution.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions, and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+* All publications and presentations based on HOOMD-blue, including any reports
+or published results obtained, in whole or in part, with HOOMD-blue, will
+acknowledge its use according to the terms posted at the time of submission on:
+http://codeblue.umich.edu/hoomd-blue/citations.html
+
+* Any electronic documents citing HOOMD-Blue will link to the HOOMD-Blue website:
+http://codeblue.umich.edu/hoomd-blue/
+
+* Apart from the above required attributions, neither the name of the copyright
+holder nor the names of HOOMD-blue's contributors may be used to endorse or
+promote products derived from this software without specific prior written
+permission.
+
+Disclaimer
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND/OR ANY
+WARRANTIES THAT THIS SOFTWARE IS FREE OF INFRINGEMENT ARE DISCLAIMED.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Maintainer: ksil
+
+/*! \file OPLSDihedralForceComputeGPU.cc
+    \brief Defines OPLSDihedralForceComputeGPU
+*/
+
+#ifdef WIN32
+#pragma warning( push )
+#pragma warning( disable : 4244 )
+#endif
+
+#include "OPLSDihedralForceComputeGPU.h"
+
+#include <boost/python.hpp>
+using namespace boost::python;
+
+#include <boost/bind.hpp>
+using namespace boost;
+
+using namespace std;
+
+/*! \param sysdef System to compute bond forces on
+*/
+OPLSDihedralForceComputeGPU::OPLSDihedralForceComputeGPU(boost::shared_ptr<SystemDefinition> sysdef)
+    : OPLSDihedralForceCompute(sysdef)
+    {
+    // can't run on the GPU if there aren't any GPUs in the execution configuration
+    if (!exec_conf->isCUDAEnabled())
+        {
+        m_exec_conf->msg->error() << "Creating an OPLSDihedralForceComputeGPU with no GPU in execution configuration" << endl;
+        throw std::runtime_error("Error initializing OPLSDihedralForceComputeGPU");
+        }
+
+    m_tuner.reset(new Autotuner(32, 1024, 32, 5, 100000, "opls_dihedral", this->m_exec_conf));
+    }
+
+/*! Internal method for computing the forces on the GPU.
+    \post The force data on the GPU is written with the calculated forces
+
+    \param timestep Current time step of the simulation
+
+    Calls gpu_compute_opls_dihedral_forces to do the dirty work.
+*/
+void OPLSDihedralForceComputeGPU::computeForces(unsigned int timestep)
+    {
+    // start the profile
+    if (m_prof) m_prof->push(exec_conf, "OPLS Dihedral");
+
+    ArrayHandle<DihedralData::members_t> d_gpu_dihedral_list(m_dihedral_data->getGPUTable(), access_location::device,access_mode::read);
+    ArrayHandle<unsigned int> d_n_dihedrals(m_dihedral_data->getNGroupsArray(), access_location::device, access_mode::read);
+    ArrayHandle<unsigned int> d_dihedrals_ABCD(m_dihedral_data->getGPUPosTable(), access_location::device, access_mode::read);
+
+    // the dihedral table is up to date: we are good to go. Call the kernel
+    ArrayHandle<Scalar4> d_pos(m_pdata->getPositions(), access_location::device, access_mode::read);
+    BoxDim box = m_pdata->getGlobalBox();
+
+    ArrayHandle<Scalar4> d_force(m_force,access_location::device,access_mode::overwrite);
+    ArrayHandle<Scalar> d_virial(m_virial,access_location::device,access_mode::overwrite);
+    ArrayHandle<Scalar4> d_params(m_params, access_location::device, access_mode::read);
+
+    // run the kernel in parallel on all GPUs
+    this->m_tuner->begin();
+    gpu_compute_opls_dihedral_forces(d_force.data,
+                                         d_virial.data,
+                                         m_virial.getPitch(),
+                                         m_pdata->getN(),
+                                         d_pos.data,
+                                         box,
+                                         d_gpu_dihedral_list.data,
+                                         d_dihedrals_ABCD.data,
+                                         m_dihedral_data->getGPUTableIndexer().getW(),
+                                         d_n_dihedrals.data,
+                                         d_params.data,
+                                         m_dihedral_data->getNTypes(),
+                                         this->m_tuner->getParam(),
+                                         m_exec_conf->getComputeCapability());
+    if (exec_conf->isCUDAErrorCheckingEnabled())
+        CHECK_CUDA_ERROR();
+    this->m_tuner->end();
+
+    if (m_prof) m_prof->pop(exec_conf);
+    }
+
+void export_OPLSDihedralForceComputeGPU()
+    {
+    class_<OPLSDihedralForceComputeGPU, boost::shared_ptr<OPLSDihedralForceComputeGPU>, bases<OPLSDihedralForceCompute>, boost::noncopyable >
+    ("OPLSDihedralForceComputeGPU", init< boost::shared_ptr<SystemDefinition> >())
+    ;
+    }

--- a/libhoomd/computes_gpu/OPLSDihedralForceComputeGPU.h
+++ b/libhoomd/computes_gpu/OPLSDihedralForceComputeGPU.h
@@ -1,0 +1,102 @@
+/*
+Highly Optimized Object-oriented Many-particle Dynamics -- Blue Edition
+(HOOMD-blue) Open Source Software License Copyright 2009-2014 The Regents of
+the University of Michigan All rights reserved.
+
+HOOMD-blue may contain modifications ("Contributions") provided, and to which
+copyright is held, by various Contributors who have granted The Regents of the
+University of Michigan the right to modify and/or distribute such Contributions.
+
+You may redistribute, use, and create derivate works of HOOMD-blue, in source
+and binary forms, provided you abide by the following conditions:
+
+* Redistributions of source code must retain the above copyright notice, this
+list of conditions, and the following disclaimer both in the code and
+prominently in any materials provided with the distribution.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions, and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+* All publications and presentations based on HOOMD-blue, including any reports
+or published results obtained, in whole or in part, with HOOMD-blue, will
+acknowledge its use according to the terms posted at the time of submission on:
+http://codeblue.umich.edu/hoomd-blue/citations.html
+
+* Any electronic documents citing HOOMD-Blue will link to the HOOMD-Blue website:
+http://codeblue.umich.edu/hoomd-blue/
+
+* Apart from the above required attributions, neither the name of the copyright
+holder nor the names of HOOMD-blue's contributors may be used to endorse or
+promote products derived from this software without specific prior written
+permission.
+
+Disclaimer
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND/OR ANY
+WARRANTIES THAT THIS SOFTWARE IS FREE OF INFRINGEMENT ARE DISCLAIMED.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Maintainer: ksil
+
+#include "OPLSDihedralForceCompute.h"
+#include "OPLSDihedralForceGPU.cuh"
+#include "Autotuner.h"
+
+/*! \file OPLSDihedralForceComputeGPU.h
+    \brief Declares the TableDihedralForceComputeGPU class
+*/
+
+#ifdef NVCC
+#error This header cannot be compiled by nvcc
+#endif
+
+#ifndef __OPLSDIHEDRALFORCECOMPUTEGPU_H__
+#define __OPLSDIHEDRALFORCECOMPUTEGPU_H__
+
+//! Computes OPLS-style dihedral potentials on the GPU
+/*! Calculates exactly the same thing as OPLSDihedralForceCompute, but on the GPU
+
+    The GPU kernel for calculating this can be found in OPLSDihedralForceComputeGPU.cu/
+    \ingroup computes
+*/
+class OPLSDihedralForceComputeGPU : public OPLSDihedralForceCompute
+    {
+    public:
+        //! Constructs the compute
+        OPLSDihedralForceComputeGPU(boost::shared_ptr<SystemDefinition> sysdef);
+
+        //! Destructor
+        virtual ~OPLSDihedralForceComputeGPU() { }
+
+        //! Set autotuner parameters
+        /*! \param enable Enable/disable autotuning
+            \param period period (approximate) in time steps when returning occurs
+        */
+        virtual void setAutotunerParams(bool enable, unsigned int period)
+            {
+            OPLSDihedralForceCompute::setAutotunerParams(enable, period);
+            m_tuner->setPeriod(period);
+            m_tuner->setEnabled(enable);
+            }
+
+    private:
+        boost::scoped_ptr<Autotuner> m_tuner; //!< Autotuner for block size
+        
+        virtual void computeForces(unsigned int timestep);
+    };
+
+//! Exports the OPLSDihedralForceComputeGPU class to python
+void export_OPLSDihedralForceComputeGPU();
+
+#endif

--- a/libhoomd/computes_gpu/OPLSDihedralForceComputeGPU.h
+++ b/libhoomd/computes_gpu/OPLSDihedralForceComputeGPU.h
@@ -54,7 +54,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Autotuner.h"
 
 /*! \file OPLSDihedralForceComputeGPU.h
-    \brief Declares the TableDihedralForceComputeGPU class
+    \brief Declares the OPLSDihedralForceComputeGPU class
 */
 
 #ifdef NVCC
@@ -65,9 +65,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define __OPLSDIHEDRALFORCECOMPUTEGPU_H__
 
 //! Computes OPLS-style dihedral potentials on the GPU
-/*! Calculates exactly the same thing as OPLSDihedralForceCompute, but on the GPU
+/*! Calculates the OPLS type dihedral force on the GPU
 
-    The GPU kernel for calculating this can be found in OPLSDihedralForceComputeGPU.cu/
+    The GPU kernel for calculating this can be found in OPLSDihedralForceComputeGPU.cu
     \ingroup computes
 */
 class OPLSDihedralForceComputeGPU : public OPLSDihedralForceCompute

--- a/libhoomd/cuda/OPLSDihedralForceGPU.cu
+++ b/libhoomd/cuda/OPLSDihedralForceGPU.cu
@@ -359,19 +359,19 @@ void gpu_compute_opls_dihedral_forces_kernel(Scalar4* d_force,
     and the y component contains sign, and the z component the multiplicity.
 */
 cudaError_t gpu_compute_opls_dihedral_forces(Scalar4* d_force,
-                                                 Scalar* d_virial,
-                                                 const unsigned int virial_pitch,
-                                                 const unsigned int N,
-                                                 const Scalar4 *d_pos,
-                                                 const BoxDim& box,
-                                                 const group_storage<4> *tlist,
-                                                 const unsigned int *dihedral_ABCD,
-                                                 const unsigned int pitch,
-                                                 const unsigned int *n_dihedrals_list,
-                                                 Scalar4 *d_params,
-                                                 unsigned int n_dihedral_types,
-                                                 int block_size,
-                                                 const unsigned int compute_capability)
+                                                Scalar* d_virial,
+                                                const unsigned int virial_pitch,
+                                                const unsigned int N,
+                                                const Scalar4 *d_pos,
+                                                const BoxDim& box,
+                                                const group_storage<4> *tlist,
+                                                const unsigned int *dihedral_ABCD,
+                                                const unsigned int pitch,
+                                                const unsigned int *n_dihedrals_list,
+                                                const Scalar4 *d_params,
+                                                const unsigned int n_dihedral_types,
+                                                const int block_size,
+                                                const unsigned int compute_capability)
     {
     assert(d_params);
 
@@ -398,7 +398,8 @@ cudaError_t gpu_compute_opls_dihedral_forces(Scalar4* d_force,
         }
 
     // run the kernel
-    gpu_compute_opls_dihedral_forces_kernel<<< grid, threads>>>(d_force, d_virial, virial_pitch, N, d_pos, d_params, box, tlist, dihedral_ABCD, pitch, n_dihedrals_list);
+    gpu_compute_opls_dihedral_forces_kernel<<< grid, threads>>>(d_force, d_virial, virial_pitch, N, d_pos, d_params,
+                                                                box, tlist, dihedral_ABCD, pitch, n_dihedrals_list);
 
     return cudaSuccess;
     }

--- a/libhoomd/cuda/OPLSDihedralForceGPU.cu
+++ b/libhoomd/cuda/OPLSDihedralForceGPU.cu
@@ -1,0 +1,402 @@
+/*
+Highly Optimized Object-oriented Many-particle Dynamics -- Blue Edition
+(HOOMD-blue) Open Source Software License Copyright 2009-2014 The Regents of
+the University of Michigan All rights reserved.
+
+HOOMD-blue may contain modifications ("Contributions") provided, and to which
+copyright is held, by various Contributors who have granted The Regents of the
+University of Michigan the right to modify and/or distribute such Contributions.
+
+You may redistribute, use, and create derivate works of HOOMD-blue, in source
+and binary forms, provided you abide by the following conditions:
+
+* Redistributions of source code must retain the above copyright notice, this
+list of conditions, and the following disclaimer both in the code and
+prominently in any materials provided with the distribution.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions, and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+* All publications and presentations based on HOOMD-blue, including any reports
+or published results obtained, in whole or in part, with HOOMD-blue, will
+acknowledge its use according to the terms posted at the time of submission on:
+http://codeblue.umich.edu/hoomd-blue/citations.html
+
+* Any electronic documents citing HOOMD-Blue will link to the HOOMD-Blue website:
+http://codeblue.umich.edu/hoomd-blue/
+
+* Apart from the above required attributions, neither the name of the copyright
+holder nor the names of HOOMD-blue's contributors may be used to endorse or
+promote products derived from this software without specific prior written
+permission.
+
+Disclaimer
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND/OR ANY
+WARRANTIES THAT THIS SOFTWARE IS FREE OF INFRINGEMENT ARE DISCLAIMED.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Maintainer: ksil
+
+#include "HarmonicDihedralForceGPU.cuh"
+#include "TextureTools.h"
+
+#ifdef WIN32
+#include <cassert>
+#else
+#include <assert.h>
+#endif
+
+#ifdef SINGLE_PRECISION
+#define __scalar2int_rn __float2int_rn
+#else
+#define __scalar2int_rn __double2int_rn
+#endif
+
+// SMALL a relatively small number
+#define SMALL Scalar(0.001)
+
+/*! \file HarmonicDihedralForceGPU.cu
+    \brief Defines GPU kernel code for calculating the harmonic dihedral forces. Used by HarmonicDihedralForceComputeGPU.
+*/
+
+//! Texture for reading dihedral parameters
+scalar4_tex_t dihedral_params_tex;
+
+//! Kernel for caculating harmonic dihedral forces on the GPU
+/*! \param d_force Device memory to write computed forces
+    \param d_virial Device memory to write computed virials
+    \param virial_pitch pitch of 2D virial array
+    \param N number of particles
+    \param d_pos particle positions on the device
+    \param d_params Parameters for the angle force
+    \param box Box dimensions for periodic boundary condition handling
+    \param tlist Dihedral data to use in calculating the forces
+    \param dihedral_ABCD List of relative atom positions in the dihedrals
+    \param pitch Pitch of 2D dihedral list
+    \param n_dihedrals_list List of numbers of dihedrals per atom
+*/
+extern "C" __global__
+void gpu_compute_harmonic_dihedral_forces_kernel(Scalar4* d_force,
+                                                 Scalar* d_virial,
+                                                 const unsigned int virial_pitch,
+                                                 const unsigned int N,
+                                                 const Scalar4 *d_pos,
+                                                 const Scalar4 *d_params,
+                                                 BoxDim box,
+                                                 const group_storage<4> *tlist,
+                                                 const unsigned int *dihedral_ABCD,
+                                                 const unsigned int pitch,
+                                                 const unsigned int *n_dihedrals_list)
+    {
+    // start by identifying which particle we are to handle
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (idx >= N)
+        return;
+
+    // load in the length of the list for this thread (MEM TRANSFER: 4 bytes)
+    int n_dihedrals = n_dihedrals_list[idx];
+
+    // read in the position of our b-particle from the a-b-c-d set. (MEM TRANSFER: 16 bytes)
+    Scalar4 idx_postype = d_pos[idx];  // we can be either a, b, or c in the a-b-c-d quartet
+    Scalar3 idx_pos = make_scalar3(idx_postype.x, idx_postype.y, idx_postype.z);
+    Scalar3 pos_a,pos_b,pos_c, pos_d; // allocate space for the a,b, and c atoms in the a-b-c-d quartet
+
+    // initialize the force to 0
+    Scalar4 force_idx = make_scalar4(Scalar(0.0), Scalar(0.0), Scalar(0.0), Scalar(0.0));
+
+    // initialize the virial to 0
+    Scalar virial_idx[6];
+    for (unsigned int i = 0; i < 6; i++)
+        virial_idx[i] = Scalar(0.0);
+
+    // loop over all dihedrals
+    for (int dihedral_idx = 0; dihedral_idx < n_dihedrals; dihedral_idx++)
+        {
+        group_storage<4> cur_dihedral = tlist[pitch*dihedral_idx + idx];
+        unsigned int cur_ABCD = dihedral_ABCD[pitch*dihedral_idx + idx];
+
+        int cur_dihedral_x_idx = cur_dihedral.idx[0];
+        int cur_dihedral_y_idx = cur_dihedral.idx[1];
+        int cur_dihedral_z_idx = cur_dihedral.idx[2];
+        int cur_dihedral_type = cur_dihedral.idx[3];
+        int cur_dihedral_abcd = cur_ABCD;
+
+        // get the a-particle's position (MEM TRANSFER: 16 bytes)
+        Scalar4 x_postype = d_pos[cur_dihedral_x_idx];
+        Scalar3 x_pos = make_scalar3(x_postype.x, x_postype.y, x_postype.z);
+        // get the c-particle's position (MEM TRANSFER: 16 bytes)
+        Scalar4 y_postype = d_pos[cur_dihedral_y_idx];
+        Scalar3 y_pos = make_scalar3(y_postype.x, y_postype.y, y_postype.z);
+        // get the c-particle's position (MEM TRANSFER: 16 bytes)
+        Scalar4 z_postype = d_pos[cur_dihedral_z_idx];
+        Scalar3 z_pos = make_scalar3(z_postype.x, z_postype.y, z_postype.z);
+
+        if (cur_dihedral_abcd == 0)
+            {
+            pos_a = idx_pos;
+            pos_b = x_pos;
+            pos_c = y_pos;
+            pos_d = z_pos;
+            }
+        if (cur_dihedral_abcd == 1)
+            {
+            pos_b = idx_pos;
+            pos_a = x_pos;
+            pos_c = y_pos;
+            pos_d = z_pos;
+            }
+        if (cur_dihedral_abcd == 2)
+            {
+            pos_c = idx_pos;
+            pos_a = x_pos;
+            pos_b = y_pos;
+            pos_d = z_pos;
+            }
+        if (cur_dihedral_abcd == 3)
+            {
+            pos_d = idx_pos;
+            pos_a = x_pos;
+            pos_b = y_pos;
+            pos_c = z_pos;
+            }
+
+        // calculate dr for a-b,c-b,and a-c
+        Scalar3 dab = pos_a - pos_b;
+        Scalar3 dcb = pos_c - pos_b;
+        Scalar3 ddc = pos_d - pos_c;
+
+        dab = box.minImage(dab);
+        dcb = box.minImage(dcb);
+        ddc = box.minImage(ddc);
+
+        Scalar3 dcbm = -dcb;
+        dcbm = box.minImage(dcbm);
+
+        // get the dihedral parameters (MEM TRANSFER: 12 bytes)
+        Scalar4 params = texFetchScalar4(d_params, dihedral_params_tex, cur_dihedral_type);
+        Scalar K = params.x;
+        Scalar sign = params.y;
+        Scalar multi = params.z;
+
+        Scalar aax = dab.y*dcbm.z - dab.z*dcbm.y;
+        Scalar aay = dab.z*dcbm.x - dab.x*dcbm.z;
+        Scalar aaz = dab.x*dcbm.y - dab.y*dcbm.x;
+
+        Scalar bbx = ddc.y*dcbm.z - ddc.z*dcbm.y;
+        Scalar bby = ddc.z*dcbm.x - ddc.x*dcbm.z;
+        Scalar bbz = ddc.x*dcbm.y - ddc.y*dcbm.x;
+
+        Scalar raasq = aax*aax + aay*aay + aaz*aaz;
+        Scalar rbbsq = bbx*bbx + bby*bby + bbz*bbz;
+        Scalar rgsq = dcbm.x*dcbm.x + dcbm.y*dcbm.y + dcbm.z*dcbm.z;
+        Scalar rg = sqrtf(rgsq);
+
+        Scalar rginv, raa2inv, rbb2inv;
+        rginv = raa2inv = rbb2inv = Scalar(0.0);
+        if (rg > Scalar(0.0)) rginv = Scalar(1.0)/rg;
+        if (raasq > Scalar(0.0)) raa2inv = Scalar(1.0)/raasq;
+        if (rbbsq > Scalar(0.0)) rbb2inv = Scalar(1.0)/rbbsq;
+        Scalar rabinv = sqrtf(raa2inv*rbb2inv);
+
+        Scalar c_abcd = (aax*bbx + aay*bby + aaz*bbz)*rabinv;
+        Scalar s_abcd = rg*rabinv*(aax*ddc.x + aay*ddc.y + aaz*ddc.z);
+
+        if (c_abcd > Scalar(1.0)) c_abcd = Scalar(1.0);
+        if (c_abcd < -Scalar(1.0)) c_abcd = -Scalar(1.0);
+
+        Scalar p = Scalar(1.0);
+        Scalar ddfab;
+        Scalar dfab = Scalar(0.0);
+        int m = __scalar2int_rn(multi);
+
+        for (int jj = 0; jj < m; jj++)
+            {
+            ddfab = p*c_abcd - dfab*s_abcd;
+            dfab = p*s_abcd + dfab*c_abcd;
+            p = ddfab;
+            }
+
+/////////////////////////
+// FROM LAMMPS: sin_shift is always 0... so dropping all sin_shift terms!!!!
+/////////////////////////
+        p *= sign;
+        dfab *= sign;
+        dfab *= -multi;
+        p += Scalar(1.0);
+
+        if (multi < Scalar(1.0))
+            {
+            p =  Scalar(1.0) + sign;
+            dfab = Scalar(0.0);
+            }
+
+        Scalar fg = dab.x*dcbm.x + dab.y*dcbm.y + dab.z*dcbm.z;
+        Scalar hg = ddc.x*dcbm.x + ddc.y*dcbm.y + ddc.z*dcbm.z;
+
+        Scalar fga = fg*raa2inv*rginv;
+        Scalar hgb = hg*rbb2inv*rginv;
+        Scalar gaa = -raa2inv*rg;
+        Scalar gbb = rbb2inv*rg;
+
+        Scalar dtfx = gaa*aax;
+        Scalar dtfy = gaa*aay;
+        Scalar dtfz = gaa*aaz;
+        Scalar dtgx = fga*aax - hgb*bbx;
+        Scalar dtgy = fga*aay - hgb*bby;
+        Scalar dtgz = fga*aaz - hgb*bbz;
+        Scalar dthx = gbb*bbx;
+        Scalar dthy = gbb*bby;
+        Scalar dthz = gbb*bbz;
+
+        //Scalar df = -K * dfab;
+        Scalar df = -K * dfab * Scalar(0.500); // the 0.5 term is for 1/2K in the forces
+
+        Scalar sx2 = df*dtgx;
+        Scalar sy2 = df*dtgy;
+        Scalar sz2 = df*dtgz;
+
+        Scalar ffax = df*dtfx;
+        Scalar ffay = df*dtfy;
+        Scalar ffaz = df*dtfz;
+
+        Scalar ffbx = sx2 - ffax;
+        Scalar ffby = sy2 - ffay;
+        Scalar ffbz = sz2 - ffaz;
+
+        Scalar ffdx = df*dthx;
+        Scalar ffdy = df*dthy;
+        Scalar ffdz = df*dthz;
+
+        Scalar ffcx = -sx2 - ffdx;
+        Scalar ffcy = -sy2 - ffdy;
+        Scalar ffcz = -sz2 - ffdz;
+
+        // Now, apply the force to each individual atom a,b,c,d
+        // and accumlate the energy/virial
+        // compute 1/4 of the energy, 1/4 for each atom in the dihedral
+        //Scalar dihedral_eng = p*K*Scalar(1.0/4.0);
+        Scalar dihedral_eng = p*K*Scalar(1.0/8.0); // the 1/8th term is (1/2)K * 1/4
+        // compute 1/4 of the virial, 1/4 for each atom in the dihedral
+        // upper triangular version of virial tensor
+        Scalar dihedral_virial[6];
+        dihedral_virial[0] = Scalar(1./4.)*(dab.x*ffax + dcb.x*ffcx + (ddc.x+dcb.x)*ffdx);
+        dihedral_virial[1] = Scalar(1./4.)*(dab.y*ffax + dcb.y*ffcx + (ddc.y+dcb.y)*ffdx);
+        dihedral_virial[2] = Scalar(1./4.)*(dab.z*ffax + dcb.z*ffcx + (ddc.z+dcb.z)*ffdx);
+        dihedral_virial[3] = Scalar(1./4.)*(dab.y*ffay + dcb.y*ffcy + (ddc.y+dcb.y)*ffdy);
+        dihedral_virial[4] = Scalar(1./4.)*(dab.z*ffay + dcb.z*ffcy + (ddc.z+dcb.z)*ffdy);
+        dihedral_virial[5] = Scalar(1./4.)*(dab.z*ffaz + dcb.z*ffcz + (ddc.z+dcb.z)*ffdz);
+
+        if (cur_dihedral_abcd == 0)
+            {
+            force_idx.x += ffax;
+            force_idx.y += ffay;
+            force_idx.z += ffaz;
+            }
+        if (cur_dihedral_abcd == 1)
+            {
+            force_idx.x += ffbx;
+            force_idx.y += ffby;
+            force_idx.z += ffbz;
+            }
+        if (cur_dihedral_abcd == 2)
+            {
+            force_idx.x += ffcx;
+            force_idx.y += ffcy;
+            force_idx.z += ffcz;
+            }
+        if (cur_dihedral_abcd == 3)
+            {
+            force_idx.x += ffdx;
+            force_idx.y += ffdy;
+            force_idx.z += ffdz;
+            }
+
+        force_idx.w += dihedral_eng;
+        for (int k = 0; k < 6; k++)
+            virial_idx[k] += dihedral_virial[k];
+        }
+
+    // now that the force calculation is complete, write out the result (MEM TRANSFER: 20 bytes)
+    d_force[idx] = force_idx;
+    for (int k = 0; k < 6; k++)
+       d_virial[k*virial_pitch+idx] = virial_idx[k];
+    }
+
+/*! \param d_force Device memory to write computed forces
+    \param d_virial Device memory to write computed virials
+    \param virial_pitch pitch of 2D virial array
+    \param N number of particles
+    \param d_pos particle positions on the GPU
+    \param box Box dimensions (in GPU format) to use for periodic boundary conditions
+    \param tlist Dihedral data to use in calculating the forces
+    \param dihedral_ABCD List of relative atom positions in the dihedrals
+    \param pitch Pitch of 2D dihedral list
+    \param n_dihedrals_list List of numbers of dihedrals per atom
+    \param d_params K, sign,multiplicity params packed as padded Scalar4 variables
+    \param n_dihedral_types Number of dihedral types in d_params
+    \param block_size Block size to use when performing calculations
+    \param compute_capability Compute capability of the device (200, 300, 350, ...)
+
+    \returns Any error code resulting from the kernel launch
+    \note Always returns cudaSuccess in release builds to avoid the cudaThreadSynchronize()
+
+    \a d_params should include one Scalar4 element per dihedral type. The x component contains K the spring constant
+    and the y component contains sign, and the z component the multiplicity.
+*/
+cudaError_t gpu_compute_harmonic_dihedral_forces(Scalar4* d_force,
+                                                 Scalar* d_virial,
+                                                 const unsigned int virial_pitch,
+                                                 const unsigned int N,
+                                                 const Scalar4 *d_pos,
+                                                 const BoxDim& box,
+                                                 const group_storage<4> *tlist,
+                                                 const unsigned int *dihedral_ABCD,
+                                                 const unsigned int pitch,
+                                                 const unsigned int *n_dihedrals_list,
+                                                 Scalar4 *d_params,
+                                                 unsigned int n_dihedral_types,
+                                                 int block_size,
+                                                 const unsigned int compute_capability)
+    {
+    assert(d_params);
+
+    static unsigned int max_block_size = UINT_MAX;
+    if (max_block_size == UINT_MAX)
+        {
+        cudaFuncAttributes attr;
+        cudaFuncGetAttributes(&attr, (const void *)gpu_compute_harmonic_dihedral_forces_kernel);
+        max_block_size = attr.maxThreadsPerBlock;
+        }
+
+    unsigned int run_block_size = min(block_size, max_block_size);
+
+    // setup the grid to run the kernel
+    dim3 grid( N / run_block_size + 1, 1, 1);
+    dim3 threads(run_block_size, 1, 1);
+
+    // bind the texture on pre sm35 devices
+    if (compute_capability < 350)
+        {
+        cudaError_t error = cudaBindTexture(0, dihedral_params_tex, d_params, sizeof(Scalar4) * n_dihedral_types);
+        if (error != cudaSuccess)
+            return error;
+        }
+
+    // run the kernel
+    gpu_compute_harmonic_dihedral_forces_kernel<<< grid, threads>>>(d_force, d_virial, virial_pitch, N, d_pos, d_params, box, tlist, dihedral_ABCD, pitch, n_dihedrals_list);
+
+    return cudaSuccess;
+    }

--- a/libhoomd/cuda/OPLSDihedralForceGPU.cuh
+++ b/libhoomd/cuda/OPLSDihedralForceGPU.cuh
@@ -62,18 +62,18 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 //! Kernel driver that computes OPLS dihedral forces for OPLSDihedralForceComputeGPU
 cudaError_t gpu_compute_opls_dihedral_forces(Scalar4* d_force,
-                                                 Scalar* d_virial,
-                                                 const unsigned int virial_pitch,
-                                                 const unsigned int N,
-                                                 const Scalar4 *d_pos,
-                                                 const BoxDim& box,
-                                                 const group_storage<4> *tlist,
-                                                 const unsigned int *dihedral_ABCD,
-                                                 const unsigned int pitch,
-                                                 const unsigned int *n_dihedrals_list,
-                                                 Scalar4 *d_params,
-                                                 unsigned int n_dihedral_types,
-                                                 int block_size,
-                                                 const unsigned int compute_capability);
+                                                Scalar* d_virial,
+                                                const unsigned int virial_pitch,
+                                                const unsigned int N,
+                                                const Scalar4 *d_pos,
+                                                const BoxDim& box,
+                                                const group_storage<4> *tlist,
+                                                const unsigned int *dihedral_ABCD,
+                                                const unsigned int pitch,
+                                                const unsigned int *n_dihedrals_list,
+                                                const Scalar4 *d_params,
+                                                const unsigned int n_dihedral_types,
+                                                const int block_size,
+                                                const unsigned int compute_capability);
 
 #endif

--- a/libhoomd/cuda/OPLSDihedralForceGPU.cuh
+++ b/libhoomd/cuda/OPLSDihedralForceGPU.cuh
@@ -1,0 +1,79 @@
+/*
+Highly Optimized Object-oriented Many-particle Dynamics -- Blue Edition
+(HOOMD-blue) Open Source Software License Copyright 2009-2014 The Regents of
+the University of Michigan All rights reserved.
+
+HOOMD-blue may contain modifications ("Contributions") provided, and to which
+copyright is held, by various Contributors who have granted The Regents of the
+University of Michigan the right to modify and/or distribute such Contributions.
+
+You may redistribute, use, and create derivate works of HOOMD-blue, in source
+and binary forms, provided you abide by the following conditions:
+
+* Redistributions of source code must retain the above copyright notice, this
+list of conditions, and the following disclaimer both in the code and
+prominently in any materials provided with the distribution.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions, and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+* All publications and presentations based on HOOMD-blue, including any reports
+or published results obtained, in whole or in part, with HOOMD-blue, will
+acknowledge its use according to the terms posted at the time of submission on:
+http://codeblue.umich.edu/hoomd-blue/citations.html
+
+* Any electronic documents citing HOOMD-Blue will link to the HOOMD-Blue website:
+http://codeblue.umich.edu/hoomd-blue/
+
+* Apart from the above required attributions, neither the name of the copyright
+holder nor the names of HOOMD-blue's contributors may be used to endorse or
+promote products derived from this software without specific prior written
+permission.
+
+Disclaimer
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND/OR ANY
+WARRANTIES THAT THIS SOFTWARE IS FREE OF INFRINGEMENT ARE DISCLAIMED.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Maintainer: ksil
+
+#include "ParticleData.cuh"
+#include "HOOMDMath.h"
+#include "BondedGroupData.cuh"
+
+/*! \file OPLSDihedralForceGPU.cuh
+    \brief Declares GPU kernel code for calculating the OPLS dihedral forces. Used by OPLSDihedralForceComputeGPU.
+*/
+
+#ifndef __OPLSDIHEDRALFORCEGPU_CUH__
+#define __OPLSDIHEDRALFORCEGPU_CUH__
+
+//! Kernel driver that computes OPLS dihedral forces for OPLSDihedralForceComputeGPU
+cudaError_t gpu_compute_opls_dihedral_forces(Scalar4* d_force,
+                                                 Scalar* d_virial,
+                                                 const unsigned int virial_pitch,
+                                                 const unsigned int N,
+                                                 const Scalar4 *d_pos,
+                                                 const BoxDim& box,
+                                                 const group_storage<4> *tlist,
+                                                 const unsigned int *dihedral_ABCD,
+                                                 const unsigned int pitch,
+                                                 const unsigned int *n_dihedrals_list,
+                                                 Scalar4 *d_params,
+                                                 unsigned int n_dihedral_types,
+                                                 int block_size,
+                                                 const unsigned int compute_capability);
+
+#endif

--- a/libhoomd/cuda/TableDihedralForceGPU.cu
+++ b/libhoomd/cuda/TableDihedralForceGPU.cu
@@ -116,7 +116,7 @@ __global__ void gpu_compute_table_dihedral_forces_kernel(Scalar4* d_force,
         return;
 
     // load in the length of the list for this thread (MEM TRANSFER: 4 bytes)
-    int n_dihedrals =n_dihedrals_list[idx];
+    int n_dihedrals = n_dihedrals_list[idx];
 
     // read in the position of our b-particle from the a-b-c triplet. (MEM TRANSFER: 16 bytes)
     Scalar4 idx_postype = device_pos[idx];  // we can be either a, b, or c in the a-b-c triplet

--- a/libhoomd/python/hoomd_module.cc
+++ b/libhoomd/python/hoomd_module.cc
@@ -78,6 +78,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "HarmonicAngleForceCompute.h"
 #include "TableAngleForceCompute.h"
 #include "HarmonicDihedralForceCompute.h"
+#include "OPLSDihedralForceCompute.h"
 #include "TableDihedralForceCompute.h"
 #include "HarmonicImproperForceCompute.h"
 #include "CGCMMAngleForceCompute.h"
@@ -488,6 +489,7 @@ BOOST_PYTHON_MODULE(hoomd)
     export_HarmonicAngleForceCompute();
     export_TableAngleForceCompute();
     export_HarmonicDihedralForceCompute();
+    export_OPLSDihedralForceCompute();
     export_TableDihedralForceCompute();
     export_HarmonicImproperForceCompute();
     export_CGCMMAngleForceCompute();

--- a/libhoomd/python/hoomd_module.cc
+++ b/libhoomd/python/hoomd_module.cc
@@ -159,6 +159,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "HarmonicAngleForceComputeGPU.h"
 #include "TableAngleForceComputeGPU.h"
 #include "HarmonicDihedralForceComputeGPU.h"
+#include "OPLSDihedralForceComputeGPU.h"
 #include "TableDihedralForceComputeGPU.h"
 #include "HarmonicImproperForceComputeGPU.h"
 #include "CGCMMAngleForceComputeGPU.h"
@@ -548,6 +549,7 @@ BOOST_PYTHON_MODULE(hoomd)
     export_HarmonicAngleForceComputeGPU();
     export_TableAngleForceComputeGPU();
     export_HarmonicDihedralForceComputeGPU();
+    export_OPLSDihedralForceComputeGPU();
     export_TableDihedralForceComputeGPU();
     export_HarmonicImproperForceComputeGPU();
     export_CGCMMAngleForceComputeGPU();

--- a/python-module/hoomd_script/dihedral.py
+++ b/python-module/hoomd_script/dihedral.py
@@ -521,16 +521,6 @@ class table(force._force):
           self.dihedral_coeff.set(dihedralname, func=_table_eval, coeff=dict(V=V_table, T=T_table, width=self.width))
           util._disable_status_lines = True;
 
-## \package hoomd_script.dihedral
-# \brief Commands that specify %dihedral forces
-#
-# Dihedrals add forces between specified quadruplets of particles and are typically used to
-# model rotation about chemical bonds. Dihedrals between particles are set when an input XML file is read
-# (init.read_xml) or when an another initializer creates them (like init.create_random_polymers)
-#
-# By themselves, dihedrals that have been specified in an input file do nothing. Only when you
-# specify a dihedral force (e.g., dihedral.harmonic or dihedral.opls) are forces actually calculated 
-# between the listed particles.
 
 ## OPLS %dihedral force
 #
@@ -538,7 +528,7 @@ class table(force._force):
 # quadruplet of particles in the simulation.
 # \f[ V(r) = \frac{1}{2}k_1 \left( 1 + \cos\left(\phi \right) \right) + \frac{1}{2}k_2 \left( 1 - \cos\left(2 \phi \right) \right)
 # + \frac{1}{2}k_3 \left( 1 + \cos\left(3 \phi \right) \right) + \frac{1}{2}k_4 \left( 1 - \cos\left(4 \phi \right) \right) \f]
-# where \f$ \phi \f$ is angle between two sides of the dihedral and \f$ k_n \f$ are the %force coefficients
+# where \f$ \phi \f$ is the angle between two sides of the dihedral and \f$ k_n \f$ are the %force coefficients
 # in the Fourier series (in energy units).
 #
 # \f$ k_1 \f$, \f$ k_2 \f$, \f$ k_3 \f$, and \f$ k_4 \f$ must be set for each type of %dihedral in the simulation using
@@ -551,7 +541,7 @@ class opls(force._force):
     #
     # \b Example:
     # \code
-    # oplsDi = dihedral.opls()
+    # opls_di = dihedral.opls()
     # \endcode
     def __init__(self):
         util.print_status_line();
@@ -581,15 +571,15 @@ class opls(force._force):
     # \param k2 Force coefficient \f$ k_2 \f$ (in energy units)
     # \param k3 Force coefficient \f$ k_3 \f$ (in energy units)
     # \param k4 Force coefficient \f$ k_4 \f$ (in energy units)
-        #
+    #
     # Using set_coeff() requires that the specified %dihedral %force has been saved in a variable. i.e.
     # \code
-    # oplsDi = dihedral.opls()
+    # opls_di = dihedral.opls()
     # \endcode
     #
     # \b Example:
     # \code
-    # oplsDi.set_coeff('dihedral1', k1=30.0, k2=15.5, k3=2.2, k4=23.8)
+    # opls_di.set_coeff('dihedral1', k1=30.0, k2=15.5, k3=2.2, k4=23.8)
     # \endcode
     #
     # The coefficients for every %dihedral type in the simulation must be set

--- a/python-module/hoomd_script/dihedral.py
+++ b/python-module/hoomd_script/dihedral.py
@@ -534,7 +534,7 @@ class table(force._force):
 
 ## OPLS %dihedral force
 #
-# The command dihedral.opls specifies an opls-style %dihedral potential energy between every defined
+# The command dihedral.opls specifies an OPLS-style %dihedral potential energy between every defined
 # quadruplet of particles in the simulation.
 # \f[ V(r) = \frac{1}{2}k_1 \left( 1 + \cos\left(\phi \right) \right) + \frac{1}{2}k_2 \left( 1 - \cos\left(2 \phi \right) \right)
 # + \frac{1}{2}k_3 \left( 1 + \cos\left(3 \phi \right) \right) + \frac{1}{2}k_4 \left( 1 - \cos\left(4 \phi \right) \right) \f]

--- a/python-module/hoomd_script/dihedral.py
+++ b/python-module/hoomd_script/dihedral.py
@@ -520,3 +520,97 @@ class table(force._force):
           util._disable_status_lines = True;
           self.dihedral_coeff.set(dihedralname, func=_table_eval, coeff=dict(V=V_table, T=T_table, width=self.width))
           util._disable_status_lines = True;
+
+## \package hoomd_script.dihedral
+# \brief Commands that specify %dihedral forces
+#
+# Dihedrals add forces between specified quadruplets of particles and are typically used to
+# model rotation about chemical bonds. Dihedrals between particles are set when an input XML file is read
+# (init.read_xml) or when an another initializer creates them (like init.create_random_polymers)
+#
+# By themselves, dihedrals that have been specified in an input file do nothing. Only when you
+# specify a dihedral force (e.g., dihedral.harmonic or dihedral.opls) are forces actually calculated 
+# between the listed particles.
+
+## OPLS %dihedral force
+#
+# The command dihedral.opls specifies an opls-style %dihedral potential energy between every defined
+# quadruplet of particles in the simulation.
+# \f[ V(r) = \frac{1}{2}k_1 \left( 1 + \cos\left(\phi \right) \right) + \frac{1}{2}k_2 \left( 1 - \cos\left(2 \phi \right) \right)
+# + \frac{1}{2}k_3 \left( 1 + \cos\left(3 \phi \right) \right) + \frac{1}{2}k_4 \left( 1 - \cos\left(4 \phi \right) \right) \f]
+# where \f$ \phi \f$ is angle between two sides of the dihedral and \f$ k_n \f$ are the %force coefficients
+# in the Fourier series (in energy units).
+#
+# \f$ k_1 \f$, \f$ k_2 \f$, \f$ k_3 \f$, and \f$ k_4 \f$ must be set for each type of %dihedral in the simulation using
+# set_coeff().
+#
+# \note Specifying the dihedral.opls command when no dihedrals are defined in the simulation results in an error.
+# \MPI_SUPPORTED
+class opls(force._force):
+    ## Specify the OPLS %dihedral %force
+    #
+    # \b Example:
+    # \code
+    # oplsDi = dihedral.opls()
+    # \endcode
+    def __init__(self):
+        util.print_status_line();
+        # check that some dihedrals are defined
+        if globals.system_definition.getDihedralData().getNGlobal() == 0:
+            globals.msg.error("No dihedrals are defined.\n");
+            raise RuntimeError("Error creating opls dihedrals");
+
+        # initialize the base class
+        force._force.__init__(self);
+
+        # create the c++ mirror class
+        if not globals.exec_conf.isCUDAEnabled():
+            self.cpp_force = hoomd.OPLSDihedralForceCompute(globals.system_definition);
+        else:
+            self.cpp_force = hoomd.OPLSDihedralForceComputeGPU(globals.system_definition);
+
+        globals.system.addCompute(self.cpp_force, self.force_name);
+
+        # variable for tracking which dihedral type coefficients have been set
+        self.opls_types_set = [];
+
+    ## Sets the OPLS coefficients for a particular %dihedral type
+    #
+    # \param dihedral_type Dihedral type to set coefficients for
+    # \param k1 Force coefficient \f$ k_1 \f$ (in energy units)
+    # \param k2 Force coefficient \f$ k_2 \f$ (in energy units)
+    # \param k3 Force coefficient \f$ k_3 \f$ (in energy units)
+    # \param k4 Force coefficient \f$ k_4 \f$ (in energy units)
+        #
+    # Using set_coeff() requires that the specified %dihedral %force has been saved in a variable. i.e.
+    # \code
+    # oplsDi = dihedral.opls()
+    # \endcode
+    #
+    # \b Example:
+    # \code
+    # oplsDi.set_coeff('dihedral1', k1=30.0, k2=15.5, k3=2.2, k4=23.8)
+    # \endcode
+    #
+    # The coefficients for every %dihedral type in the simulation must be set
+    # before the run() can be started.
+    def set_coeff(self, dihedral_type, k1, k2, k3, k4):
+        util.print_status_line();
+
+        # set the parameters for the appropriate type
+        self.cpp_force.setParams(globals.system_definition.getDihedralData().getTypeByName(dihedral_type),
+                                    k1, k2, k3, k4);
+
+        # track which particle types we have set
+        if not dihedral_type in self.opls_types_set:
+            self.opls_types_set.append(dihedral_type);
+
+    def update_coeffs(self):
+        # get a list of all dihedral types in the simulation
+        # check to see if all particle types have been set
+        ntypes = globals.system_definition.getDihedralData().getNTypes();
+        for i in range(0, ntypes):
+            cur_type = globals.system_definition.getDihedralData().getNameByType(i);
+            if not cur_type in self.opls_types_set:
+                globals.msg.error(str(cur_type) + " coefficients missing in dihedral.opls\n");
+                raise RuntimeError("Error updating coefficients");

--- a/test/hoomd_script/test_dihedral_opls.py
+++ b/test/hoomd_script/test_dihedral_opls.py
@@ -1,0 +1,52 @@
+# -*- coding: iso-8859-1 -*-
+# Maintainer: joaander
+
+from hoomd_script import *
+import unittest
+import os
+
+# tests dihedral.harmonic
+class dihedral_opls_tests (unittest.TestCase):
+    def setUp(self):
+        print
+        # create a polymer system and add a dihedral to it
+        self.polymer1 = dict(bond_len=1.2, type=['A']*6 + ['B']*7 + ['A']*6, bond="linear", count=100);
+        self.polymer2 = dict(bond_len=1.2, type=['B']*4, bond="linear", count=10)
+        self.polymers = [self.polymer1, self.polymer2]
+        self.box = data.boxdim(L=35);
+        self.separation=dict(A=0.35, B=0.35)
+        sys = init.create_random_polymers(box=self.box, polymers=self.polymers, separation=self.separation);
+
+        dihedral_data = globals.system_definition.getDihedralData();
+        sys.dihedrals.add('dihedralA', 0, 1, 2, 3);
+
+        sorter.set_params(grid=8)
+
+    # test to see that se can create an OPLS dihedral
+    def test_create(self):
+        dihedral.opls();
+
+    # test setting coefficients
+    def test_set_coeff(self):
+        oplsdi = dihedral.opls();
+        oplsdi.set_coeff('dihedralA', k1=1.0, k2=2.0, k3=3.0, k4=4.0)
+        all = group.all();
+        integrate.mode_standard(dt=0.005);
+        integrate.nve(all);
+        run(100);
+
+    # test coefficient not set checking
+    def test_set_coeff_fail(self):
+        oplsdi = dihedral.opls();
+        all = group.all();
+        integrate.mode_standard(dt=0.005);
+        integrate.nve(all);
+        self.assertRaises(RuntimeError, run, 100);
+
+    def tearDown(self):
+        init.reset();
+
+
+
+if __name__ == '__main__':
+    unittest.main(argv = ['test.py', '-v'])

--- a/test/hoomd_script/test_dihedral_opls.py
+++ b/test/hoomd_script/test_dihedral_opls.py
@@ -1,5 +1,5 @@
 # -*- coding: iso-8859-1 -*-
-# Maintainer: joaander
+# Maintainer: ksil
 
 from hoomd_script import *
 import unittest

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -93,6 +93,7 @@ set(TEST_LIST
     test_table_dihedral_force
     test_table_angle_force
     test_gridshift_correct
+    test_opls_dihedral_force
     )
 
     # put the longest tests last

--- a/test/unit/test_opls_dihedral_force.cc
+++ b/test/unit/test_opls_dihedral_force.cc
@@ -1,0 +1,614 @@
+/*
+Highly Optimized Object-oriented Many-particle Dynamics -- Blue Edition
+(HOOMD-blue) Open Source Software License Copyright 2009-2014 The Regents of
+the University of Michigan All rights reserved.
+
+HOOMD-blue may contain modifications ("Contributions") provided, and to which
+copyright is held, by various Contributors who have granted The Regents of the
+University of Michigan the right to modify and/or distribute such Contributions.
+
+You may redistribute, use, and create derivate works of HOOMD-blue, in source
+and binary forms, provided you abide by the following conditions:
+
+* Redistributions of source code must retain the above copyright notice, this
+list of conditions, and the following disclaimer both in the code and
+prominently in any materials provided with the distribution.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions, and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+* All publications and presentations based on HOOMD-blue, including any reports
+or published results obtained, in whole or in part, with HOOMD-blue, will
+acknowledge its use according to the terms posted at the time of submission on:
+http://codeblue.umich.edu/hoomd-blue/citations.html
+
+* Any electronic documents citing HOOMD-Blue will link to the HOOMD-Blue website:
+http://codeblue.umich.edu/hoomd-blue/
+
+* Apart from the above required attributions, neither the name of the copyright
+holder nor the names of HOOMD-blue's contributors may be used to endorse or
+promote products derived from this software without specific prior written
+permission.
+
+Disclaimer
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND/OR ANY
+WARRANTIES THAT THIS SOFTWARE IS FREE OF INFRINGEMENT ARE DISCLAIMED.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifdef WIN32
+#pragma warning( push )
+#pragma warning( disable : 4103 4244 )
+#endif
+
+#include <iostream>
+
+#include <boost/bind.hpp>
+#include <boost/function.hpp>
+
+#include "OPLSDihedralForceCompute.h"
+#include "ConstForceCompute.h"
+#ifdef ENABLE_CUDA
+#include "OPLSDihedralForceComputeGPU.h"
+#endif
+
+#include <stdio.h>
+
+#include "Initializers.h"
+#include "SnapshotSystemData.h"
+
+using namespace std;
+using namespace boost;
+
+//! Name the boost unit test module
+#define BOOST_TEST_MODULE OPLSDihedralForceTests
+#include "boost_utf_configure.h"
+
+//! Typedef to make using the boost::function factory easier
+typedef boost::function<boost::shared_ptr<OPLSDihedralForceCompute>  (boost::shared_ptr<SystemDefinition> sysdef)> dihedralforce_creator;
+
+//! Perform some simple functionality tests of any BondForceCompute
+void dihedral_force_basic_tests(dihedralforce_creator tf_creator, boost::shared_ptr<ExecutionConfiguration> exec_conf)
+    {
+    // start with the simplest possible test: 4 particles in a huge box with only one dihedral type - no dihedrals
+    boost::shared_ptr<SystemDefinition> sysdef_4(new SystemDefinition(4, BoxDim(2.5), 1, 0, 0, 1, 0, exec_conf));
+    boost::shared_ptr<ParticleData> pdata_4 = sysdef_4->getParticleData();
+
+    pdata_4->setPosition(0,make_scalar3(1.0,0.0,0.0));
+    pdata_4->setPosition(1,make_scalar3(1.0,0.5,0));
+    pdata_4->setPosition(2,make_scalar3(0.7,0.3,-0.2));
+    pdata_4->setPosition(3,make_scalar3(0,0.4,-0.6));
+
+    // create the dihedral force compute to check
+    boost::shared_ptr<OPLSDihedralForceCompute> fc_4 = tf_creator(sysdef_4);
+    
+    // k1 = 1.5, k2 = 6.2, k3 = 1.7, k4 = 3.0
+    fc_4->setParams(0, 1.5, 6.2, 1.7, 3.0);
+
+    // compute the force (should be 0) and check the results
+    fc_4->compute(0);
+
+    {
+    GPUArray<Scalar4>& force_array_1 =  fc_4->getForceArray();
+    GPUArray<Scalar>& virial_array_1 =  fc_4->getVirialArray();
+    unsigned int pitch = 0;
+    ArrayHandle<Scalar4> h_force_1(force_array_1,access_location::host,access_mode::read);
+    ArrayHandle<Scalar> h_virial_1(virial_array_1,access_location::host,access_mode::read);
+
+    // check that the force is correct, it should be 0 since we haven't created any dihedrals yet
+    MY_BOOST_CHECK_SMALL(h_force_1.data[0].x, tol);
+    MY_BOOST_CHECK_SMALL(h_force_1.data[0].y, tol);
+    MY_BOOST_CHECK_SMALL(h_force_1.data[0].z, tol);
+    MY_BOOST_CHECK_SMALL(h_force_1.data[0].w, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_1.data[0*pitch], tol);
+    MY_BOOST_CHECK_SMALL(h_virial_1.data[1*pitch], tol);
+    MY_BOOST_CHECK_SMALL(h_virial_1.data[2*pitch], tol);
+    MY_BOOST_CHECK_SMALL(h_virial_1.data[3*pitch], tol);
+    MY_BOOST_CHECK_SMALL(h_virial_1.data[4*pitch], tol);
+    MY_BOOST_CHECK_SMALL(h_virial_1.data[5*pitch], tol);
+    }
+
+    // add a dihedral and check the force again
+    sysdef_4->getDihedralData()->addBondedGroup(Dihedral(0,0,1,2,3)); // add type 0 dihedral bewtween atoms 0-1-2-3
+    fc_4->compute(1);
+
+    {
+    // this time there should be a force
+    GPUArray<Scalar4>& force_array_2 =  fc_4->getForceArray();
+    GPUArray<Scalar>& virial_array_2 =  fc_4->getVirialArray();
+    unsigned int pitch = virial_array_2.getPitch();
+    ArrayHandle<Scalar4> h_force_2(force_array_2,access_location::host,access_mode::read);
+    ArrayHandle<Scalar> h_virial_2(virial_array_2,access_location::host,access_mode::read);
+    
+    MY_BOOST_CHECK_CLOSE(h_force_2.data[0].x, 6.40868096, tol);
+    MY_BOOST_CHECK_SMALL(h_force_2.data[0].y, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_2.data[0].z, -9.61302145, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_2.data[0].w, 0.07393705, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_2.data[0*pitch+0]
+                        +h_virial_2.data[3*pitch+0]
+                        +h_virial_2.data[5*pitch+0], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_2.data[1].x, 5.77846043, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_2.data[1].y, 1.68346581, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_2.data[1].z, -10.35115646, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_2.data[1].w, 0.07393705, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_2.data[0*pitch+1]
+                        +h_virial_2.data[3*pitch+1]
+                        +h_virial_2.data[5*pitch+1], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_2.data[2].x, -17.48694118, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_2.data[2].y, -2.74342577, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_2.data[2].z, 28.97383755, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_2.data[2].w, 0.07393705, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_2.data[0*pitch+2]
+                        +h_virial_2.data[3*pitch+2]
+                        +h_virial_2.data[5*pitch+2], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_2.data[3].x, 5.29979978, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_2.data[3].y, 1.05995995, loose_tol);
+    MY_BOOST_CHECK_CLOSE(h_force_2.data[3].z, -9.00965963, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_2.data[3].w, 0.07393705, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_2.data[0*pitch+3]
+                        +h_virial_2.data[3*pitch+3]
+                        +h_virial_2.data[5*pitch+3], tol);
+    }
+
+    // rearrange the two particles in memory and see if they are properly updated
+    {
+    ArrayHandle<Scalar4> h_pos(pdata_4->getPositions(), access_location::host, access_mode::readwrite);
+    ArrayHandle<unsigned int> h_tag(pdata_4->getTags(), access_location::host, access_mode::readwrite);
+    ArrayHandle<unsigned int> h_rtag(pdata_4->getRTags(), access_location::host, access_mode::readwrite);
+
+    std::swap(h_pos.data[0],h_pos.data[1]);
+    std::swap(h_tag.data[0],h_tag.data[1]);
+    std::swap(h_rtag.data[0], h_rtag.data[1]);
+    }
+
+    // notify that we made the sort
+    pdata_4->notifyParticleSort();
+    // recompute at the same timestep, the forces should still be updated
+    fc_4->compute(1);
+
+    {
+    GPUArray<Scalar4>& force_array_3 =  fc_4->getForceArray();
+    GPUArray<Scalar>& virial_array_3 =  fc_4->getVirialArray();
+    unsigned int pitch = virial_array_3.getPitch();
+    ArrayHandle<Scalar4> h_force_3(force_array_3,access_location::host,access_mode::read);
+    ArrayHandle<Scalar> h_virial_3(virial_array_3,access_location::host,access_mode::read);
+
+    MY_BOOST_CHECK_CLOSE(h_force_3.data[1].x, 6.40868096, tol);
+    MY_BOOST_CHECK_SMALL(h_force_3.data[1].y, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_3.data[1].z, -9.61302145, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_3.data[1].w, 0.07393705, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_3.data[0*pitch+0]
+                        +h_virial_3.data[3*pitch+0]
+                        +h_virial_3.data[5*pitch+0], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_3.data[0].x, 5.77846043, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_3.data[0].y, 1.68346581, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_3.data[0].z, -10.35115646, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_3.data[0].w, 0.07393705, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_3.data[0*pitch+1]
+                        +h_virial_3.data[3*pitch+1]
+                        +h_virial_3.data[5*pitch+1], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_3.data[2].x, -17.48694118, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_3.data[2].y, -2.74342577, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_3.data[2].z, 28.97383755, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_3.data[2].w, 0.07393705, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_3.data[0*pitch+2]
+                        +h_virial_3.data[3*pitch+2]
+                        +h_virial_3.data[5*pitch+2], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_3.data[3].x, 5.29979978, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_3.data[3].y, 1.05995995, loose_tol);
+    MY_BOOST_CHECK_CLOSE(h_force_3.data[3].z, -9.00965963, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_3.data[3].w, 0.07393705, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_3.data[0*pitch+3]
+                        +h_virial_3.data[3*pitch+3]
+                        +h_virial_3.data[5*pitch+3], tol);
+    }
+    
+    {
+    ArrayHandle<Scalar4> h_pos(pdata_4->getPositions(), access_location::host, access_mode::readwrite);
+
+    // translate all particles and wrap them back into the box
+    Scalar3 shift = make_scalar3(.5,0,1);
+    int3 img = make_int3(0,0,0);
+    const BoxDim& box = pdata_4->getBox();
+    h_pos.data[0] = make_scalar4(h_pos.data[0].x+shift.x, h_pos.data[0].y+shift.y,h_pos.data[0].z + shift.z,h_pos.data[0].w);
+    box.wrap(h_pos.data[0], img);
+    h_pos.data[1] = make_scalar4(h_pos.data[1].x+shift.x, h_pos.data[1].y+shift.y,h_pos.data[1].z + shift.z,h_pos.data[1].w);
+    box.wrap(h_pos.data[1], img);
+    h_pos.data[2] = make_scalar4(h_pos.data[2].x+shift.x, h_pos.data[2].y+shift.y,h_pos.data[2].z + shift.z,h_pos.data[2].w);
+    box.wrap(h_pos.data[2], img);
+    h_pos.data[3] = make_scalar4(h_pos.data[3].x+shift.x, h_pos.data[3].y+shift.y,h_pos.data[3].z + shift.z,h_pos.data[3].w);
+    box.wrap(h_pos.data[3], img);
+    }
+
+    fc_4->compute(2);
+    {
+    GPUArray<Scalar4>& force_array_4 =  fc_4->getForceArray();
+    GPUArray<Scalar>& virial_array_4 =  fc_4->getVirialArray();
+    unsigned int pitch = virial_array_4.getPitch();
+    ArrayHandle<Scalar4> h_force_4(force_array_4,access_location::host,access_mode::read);
+    ArrayHandle<Scalar> h_virial_4(virial_array_4,access_location::host,access_mode::read);
+
+    MY_BOOST_CHECK_CLOSE(h_force_4.data[1].x, 6.40868096, tol);
+    MY_BOOST_CHECK_SMALL(h_force_4.data[1].y, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_4.data[1].z, -9.61302145, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_4.data[1].w, 0.07393705, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_4.data[0*pitch+0]
+                        +h_virial_4.data[3*pitch+0]
+                        +h_virial_4.data[5*pitch+0], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_4.data[0].x, 5.77846043, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_4.data[0].y, 1.68346581, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_4.data[0].z, -10.35115646, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_4.data[0].w, 0.07393705, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_4.data[0*pitch+1]
+                        +h_virial_4.data[3*pitch+1]
+                        +h_virial_4.data[5*pitch+1], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_4.data[2].x, -17.48694118, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_4.data[2].y, -2.74342577, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_4.data[2].z, 28.97383755, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_4.data[2].w, 0.07393705, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_4.data[0*pitch+2]
+                        +h_virial_4.data[3*pitch+2]
+                        +h_virial_4.data[5*pitch+2], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_4.data[3].x, 5.29979978, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_4.data[3].y, 1.05995995, loose_tol);
+    MY_BOOST_CHECK_CLOSE(h_force_4.data[3].z, -9.00965963, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_4.data[3].w, 0.07393705, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_4.data[0*pitch+3]
+                        +h_virial_4.data[3*pitch+3]
+                        +h_virial_4.data[5*pitch+3], tol);
+    }
+
+    // now test a position with a negative dihedral angle
+    pdata_4->setPosition(0,make_scalar3(1.0,0.0,0.0));
+    pdata_4->setPosition(1,make_scalar3(1.0,0.5,0));
+    pdata_4->setPosition(2,make_scalar3(0.7,0.3,0.3));
+    pdata_4->setPosition(3,make_scalar3(0,0.4,0.6));
+    fc_4->compute(3);
+
+    {
+    GPUArray<Scalar4>& force_array_5 =  fc_4->getForceArray();
+    GPUArray<Scalar>& virial_array_5 =  fc_4->getVirialArray();
+    unsigned int pitch = virial_array_5.getPitch();
+    ArrayHandle<Scalar4> h_force_5(force_array_5,access_location::host,access_mode::read);
+    ArrayHandle<Scalar> h_virial_5(virial_array_5,access_location::host,access_mode::read);
+
+    MY_BOOST_CHECK_CLOSE(h_force_5.data[1].x, 19.30099804, tol);
+    MY_BOOST_CHECK_SMALL(h_force_5.data[1].y, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_5.data[1].z, 19.30099804, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_5.data[1].w, 1.51788878, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_5.data[0*pitch+1]
+                        +h_virial_5.data[3*pitch+1]
+                        +h_virial_5.data[5*pitch+1], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_5.data[0].x, 2.37592759, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_5.data[0].y, 17.20499296, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_5.data[0].z, 13.84592290, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_5.data[0].w, 1.51788878, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_5.data[0*pitch+0]
+                        +h_virial_5.data[3*pitch+0]
+                        +h_virial_5.data[5*pitch+0], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_5.data[2].x, -31.81558221, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_5.data[2].y, -30.72320175, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_5.data[2].z, -52.29771667, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_5.data[2].w, 1.51788878, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_5.data[0*pitch+2]
+                        +h_virial_5.data[3*pitch+2]
+                        +h_virial_5.data[5*pitch+2], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_5.data[3].x, 10.13865656, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_5.data[3].y, 13.51820875, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_5.data[3].z, 19.15079572, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_5.data[3].w, 1.51788878, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_5.data[0*pitch+3]
+                        +h_virial_5.data[3*pitch+3]
+                        +h_virial_5.data[5*pitch+3], tol);
+    }
+
+    // test an 8-particle system with two non-overlapping dihedrals
+    boost::shared_ptr<SystemDefinition> sysdef_8(new SystemDefinition(8, BoxDim(50.0), 1, 0, 0, 2, 0, exec_conf));
+    boost::shared_ptr<ParticleData> pdata_8 = sysdef_8->getParticleData();
+
+    pdata_8->setPosition(0, make_scalar3(1.0,0.0,0.0));
+    pdata_8->setPosition(1, make_scalar3(3.0,1.2,2.1));
+    pdata_8->setPosition(2, make_scalar3(0.0,0.7,3.2));
+    pdata_8->setPosition(3, make_scalar3(4.7,-0.5,-0.3));
+    pdata_8->setPosition(4, make_scalar3(4.8,1.1,0.0));
+    pdata_8->setPosition(5, make_scalar3(3.8,0.0,-2.0));
+    pdata_8->setPosition(6, make_scalar3(0.0,2.9,-1.7));
+    pdata_8->setPosition(7, make_scalar3(-2.0,0.3,0.7));
+
+    boost::shared_ptr<OPLSDihedralForceCompute> fc_8 = tf_creator(sysdef_8);
+    fc_8->setParams(0, 2.0, 3.0, 4.0, 5.0);
+    fc_8->setParams(1, 5.2, 4.2, 3.2, 1.2);
+
+    sysdef_8->getDihedralData()->addBondedGroup(Dihedral(0, 0,1,2,3));
+    sysdef_8->getDihedralData()->addBondedGroup(Dihedral(1, 4,5,6,7));
+
+    fc_8->compute(0);
+
+    {
+    // check that the forces are correctly computed
+    GPUArray<Scalar4>& force_array_6 =  fc_8->getForceArray();
+    GPUArray<Scalar>& virial_array_6 =  fc_8->getVirialArray();
+    unsigned int pitch = virial_array_6.getPitch();
+    ArrayHandle<Scalar4> h_force_6(force_array_6,access_location::host,access_mode::read);
+    ArrayHandle<Scalar> h_virial_6(virial_array_6,access_location::host,access_mode::read);
+
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[0].x, 0.42570372, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[0].y, -1.52678552, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[0].z, 0.46701674, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[0].w, 2.09533111, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_6.data[0*pitch+0]
+                        +h_virial_6.data[3*pitch+0]
+                        +h_virial_6.data[5*pitch+0], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[1].x, 0.80582443, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[1].y, -0.93440123, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[1].z, 1.77297516, tol); // 5.650116
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[1].w, 2.09533111, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_6.data[0*pitch+1]
+                        +h_virial_6.data[3*pitch+1]
+                        +h_virial_6.data[5*pitch+1], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[2].x, -0.59432265, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[2].y, 1.35489836, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[2].z, -1.00501706, tol); //
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[2].w, 2.09533111, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_6.data[0*pitch+2]
+                        +h_virial_6.data[3*pitch+2]
+                        +h_virial_6.data[5*pitch+2], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[3].x, -0.63720550, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[3].y, 1.10628839, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[3].z, -1.23497484, tol); //
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[3].w, 2.09533111, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_6.data[0*pitch+3]
+                        +h_virial_6.data[3*pitch+3]
+                        +h_virial_6.data[5*pitch+3], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[4].x, -0.40576686, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[4].y, -0.58602527, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[4].z, 0.52519733, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[4].w, 2.10324711, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_6.data[0*pitch+4]
+                        +h_virial_6.data[3*pitch+4]
+                        +h_virial_6.data[5*pitch+4], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[5].x, 0.41329413, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[5].y, 0.59437186, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[5].z, -0.51053556, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[5].w, 2.10324711, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_6.data[0*pitch+5]
+                        +h_virial_6.data[3*pitch+5]
+                        +h_virial_6.data[5*pitch+5], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[6].x, -0.22370415,tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[6].y, -0.24630873, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[6].z, -0.45260150, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[6].w, 2.10324711, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_6.data[0*pitch+6]
+                        +h_virial_6.data[3*pitch+6]
+                        +h_virial_6.data[5*pitch+6], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[7].x, 0.21617688, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[7].y, 0.23796214, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[7].z, 0.43793972, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_6.data[7].w, 2.10324711, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_6.data[0*pitch+7]
+                        +h_virial_6.data[3*pitch+7]
+                        +h_virial_6.data[5*pitch+7], tol);
+    }
+
+    // test a 5-particle system with one dihedral type on two overlapping sets of particles
+    boost::shared_ptr<SystemDefinition> sysdef_5(new SystemDefinition(5, BoxDim(50.0), 1, 0, 0, 1, 0, exec_conf));
+    boost::shared_ptr<ParticleData> pdata_5 = sysdef_5->getParticleData();
+
+    pdata_5->setPosition(0, make_scalar3(1.0,0.0,0.0));
+    pdata_5->setPosition(1, make_scalar3(3.0,1.2,2.1));
+    pdata_5->setPosition(2, make_scalar3(0.0,0.7,3.2));
+    pdata_5->setPosition(3, make_scalar3(4.7,-0.5,-0.3));
+    pdata_5->setPosition(4, make_scalar3(4.8,1.1,0.0));
+
+    // build the dihedral force compute and try it out
+    boost::shared_ptr<OPLSDihedralForceCompute> fc_5 = tf_creator(sysdef_5);
+    fc_5->setParams(0, 1.2, 3.3, 4.2, 6.4);
+
+    sysdef_5->getDihedralData()->addBondedGroup(Dihedral(0, 0,1,2,3));
+    sysdef_5->getDihedralData()->addBondedGroup(Dihedral(0, 1,2,3,4));
+
+    fc_5->compute(0);
+
+    {
+    GPUArray<Scalar4>& force_array_7 =  fc_5->getForceArray();
+    GPUArray<Scalar>& virial_array_7 =  fc_5->getVirialArray();
+    unsigned int pitch = virial_array_7.getPitch();
+    ArrayHandle<Scalar4> h_force_7(force_array_7,access_location::host,access_mode::read);
+    ArrayHandle<Scalar> h_virial_7(virial_array_7,access_location::host,access_mode::read);
+
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[0].x, 0.65834052, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[0].y, -2.36113691, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[0].z, 0.72223011, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[0].w, 2.21706239, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_7.data[0*pitch+0]
+                        +h_virial_7.data[3*pitch+0]
+                        +h_virial_7.data[5*pitch+0], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[1].x, -0.73383345, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[1].y, 1.99259791, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[1].z, -1.09563763, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[1].w, 4.37805164, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_7.data[0*pitch+1]
+                        +h_virial_7.data[3*pitch+1]
+                        +h_virial_7.data[5*pitch+1], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[2].x, -0.09368793, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[2].y, 0.38994288, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[2].z, 0.13888332, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[2].w, 4.37805164, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_7.data[0*pitch+2]
+                        +h_virial_7.data[3*pitch+2]
+                        +h_virial_7.data[5*pitch+2], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[3].x, -2.61415944, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[3].y, 0.91345850, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[3].z, -3.82362845, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[3].w, 4.37805164, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_7.data[0*pitch+3]
+                        +h_virial_7.data[3*pitch+3]
+                        +h_virial_7.data[5*pitch+3], tol);
+
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[4].x, 2.78334029, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[4].y, -0.93486239, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[4].z, 4.05815265, tol);
+    MY_BOOST_CHECK_CLOSE(h_force_7.data[4].w, 2.16098925, tol);
+    MY_BOOST_CHECK_SMALL(h_virial_7.data[0*pitch+4]
+                        +h_virial_7.data[3*pitch+4]
+                        +h_virial_7.data[5*pitch+4], tol);
+    }
+    }
+
+//! Compares the output of two OPLSDihedralForceComputes
+void dihedral_force_comparison_tests(dihedralforce_creator tf_creator1,
+                                     dihedralforce_creator tf_creator2,
+                                     boost::shared_ptr<ExecutionConfiguration> exec_conf)
+    {
+    const unsigned int N = 1000;
+
+    // create a particle system to sum forces on
+    // just randomly place particles. We don't really care how huge the bond forces get: this is just a unit test
+    RandomInitializer rand_init(N, Scalar(0.2), Scalar(0.9), "A");
+    boost::shared_ptr<SnapshotSystemData> snap = rand_init.getSnapshot();
+    snap->dihedral_data.type_mapping.push_back("A");
+    boost::shared_ptr<SystemDefinition> sysdef(new SystemDefinition(snap, exec_conf));
+
+    boost::shared_ptr<OPLSDihedralForceCompute> fc1 = tf_creator1(sysdef);
+    boost::shared_ptr<OPLSDihedralForceCompute> fc2 = tf_creator2(sysdef);
+    fc1->setParams(0, 1.1, 2.2, 4.5, 3.6);
+    fc2->setParams(0, 1.1, 2.2, 4.5, 3.6);
+
+    // add dihedrals
+    for (unsigned int i = 0; i < N-3; i++)
+        {
+        sysdef->getDihedralData()->addBondedGroup(Dihedral(0, i, i+1,i+2, i+3));
+        }
+
+    // compute the forces
+    fc1->compute(0);
+    fc2->compute(0);
+
+    // verify that the forces are identical (within roundoff errors)
+    {
+    GPUArray<Scalar4>& force_array_7 =  fc1->getForceArray();
+    GPUArray<Scalar>& virial_array_7 =  fc1->getVirialArray();
+    unsigned int pitch = virial_array_7.getPitch();
+    ArrayHandle<Scalar4> h_force_7(force_array_7,access_location::host,access_mode::read);
+    ArrayHandle<Scalar> h_virial_7(virial_array_7,access_location::host,access_mode::read);
+    GPUArray<Scalar4>& force_array_8 =  fc2->getForceArray();
+    GPUArray<Scalar>& virial_array_8 =  fc2->getVirialArray();
+    ArrayHandle<Scalar4> h_force_8(force_array_8,access_location::host,access_mode::read);
+    ArrayHandle<Scalar> h_virial_8(virial_array_8,access_location::host,access_mode::read);
+
+    // compare average deviation between the two computes
+    double deltaf2 = 0.0;
+    double deltape2 = 0.0;
+    double deltav2[6];
+    for (unsigned int i = 0; i < 6; i++)
+        deltav2[i] = 0.0;
+
+    for (unsigned int i = 0; i < N; i++)
+        {
+        deltaf2 += double(h_force_8.data[i].x - h_force_7.data[i].x) * double(h_force_8.data[i].x - h_force_7.data[i].x);
+        deltaf2 += double(h_force_8.data[i].y - h_force_7.data[i].y) * double(h_force_8.data[i].y - h_force_7.data[i].y);
+        deltaf2 += double(h_force_8.data[i].z - h_force_7.data[i].z) * double(h_force_8.data[i].z - h_force_7.data[i].z);
+        deltape2 += double(h_force_8.data[i].w - h_force_7.data[i].w) * double(h_force_8.data[i].w - h_force_7.data[i].w);
+        for (unsigned int j = 0; j < 6; j++)
+            deltav2[j] += double(h_virial_8.data[j*pitch+i] - h_virial_7.data[j*pitch+i]) * double(h_virial_8.data[j*pitch+i] - h_virial_7.data[j*pitch+i]);
+
+        // also check that each individual calculation is somewhat close
+        }
+    deltaf2 /= double(N);
+    deltape2 /= double(N);
+    for (unsigned int j = 0; j < 6; j++)
+        deltav2[j] /= double(N);
+
+    BOOST_CHECK_SMALL(deltaf2, double(tol_small));
+    BOOST_CHECK_SMALL(deltape2, double(tol_small));
+    BOOST_CHECK_SMALL(deltav2[0], double(tol_small));
+    BOOST_CHECK_SMALL(deltav2[1], double(tol_small));
+    BOOST_CHECK_SMALL(deltav2[2], double(tol_small));
+    BOOST_CHECK_SMALL(deltav2[3], double(tol_small));
+    BOOST_CHECK_SMALL(deltav2[4], double(tol_small));
+    BOOST_CHECK_SMALL(deltav2[5], double(tol_small));
+    }
+    }
+
+//! OPLSDihedralForceCompute creator for dihedral_force_basic_tests()
+boost::shared_ptr<OPLSDihedralForceCompute> base_class_tf_creator(boost::shared_ptr<SystemDefinition> sysdef)
+    {
+    return boost::shared_ptr<OPLSDihedralForceCompute>(new OPLSDihedralForceCompute(sysdef));
+    }
+
+#ifdef ENABLE_CUDA
+//! DihedralForceCompute creator for bond_force_basic_tests()
+boost::shared_ptr<OPLSDihedralForceCompute> gpu_tf_creator(boost::shared_ptr<SystemDefinition> sysdef)
+    {
+    return boost::shared_ptr<OPLSDihedralForceCompute>(new OPLSDihedralForceComputeGPU(sysdef));
+    }
+#endif
+
+//! boost test case for dihedral forces on the CPU
+BOOST_AUTO_TEST_CASE( OPLSDihedralForceCompute_basic )
+    {
+    printf(" IN BOOST_AUTO_TEST_CASE: CPU \n");
+    dihedralforce_creator tf_creator = bind(base_class_tf_creator, _1);
+    dihedral_force_basic_tests(tf_creator, boost::shared_ptr<ExecutionConfiguration>(new ExecutionConfiguration(ExecutionConfiguration::CPU)));
+    }
+
+#ifdef ENABLE_CUDA
+//! boost test case for dihedral forces on the GPU
+BOOST_AUTO_TEST_CASE( OPLSDihedralForceComputeGPU_basic )
+    {
+    printf(" IN BOOST_AUTO_TEST_CASE: GPU \n");
+    dihedralforce_creator tf_creator = bind(gpu_tf_creator, _1);
+    dihedral_force_basic_tests(tf_creator, boost::shared_ptr<ExecutionConfiguration>(new ExecutionConfiguration(ExecutionConfiguration::GPU)));
+    }
+
+//! boost test case for comparing bond GPU and CPU BondForceComputes
+BOOST_AUTO_TEST_CASE( OPLSDihedralForceComputeGPU_compare )
+    {
+    dihedralforce_creator tf_creator_gpu = bind(gpu_tf_creator, _1);
+    dihedralforce_creator tf_creator = bind(base_class_tf_creator, _1);
+    dihedral_force_comparison_tests(tf_creator, tf_creator_gpu, boost::shared_ptr<ExecutionConfiguration>(new ExecutionConfiguration(ExecutionConfiguration::GPU)));
+    }
+
+//! boost test case for comparing calculation on the CPU to multi-gpu ones
+BOOST_AUTO_TEST_CASE( OPLSDihedralForce_MultiGPU_compare)
+    {
+    boost::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::GPU));
+
+    dihedralforce_creator tf_creator_gpu = bind(gpu_tf_creator, _1);
+    dihedralforce_creator tf_creator = bind(base_class_tf_creator, _1);
+    dihedral_force_comparison_tests(tf_creator, tf_creator_gpu, exec_conf);
+    }
+#endif


### PR DESCRIPTION
This branch fully implements OPLS-style proper dihedrals with the appropriate script, CPU, GPU, and unit test code. In benchmarks of 32,000 four-particle chains (NVE simulation with harmonic bonds, harmonic angles, and OPLS-style dihedrals) on a GeForce GTX 670, this implementation is ~18% faster in absolute time steps per second than implementing equivalent multiple harmonic dihedrals.

Kevin Silmore
Panagiotopoulos Group, Princeton University