### PR TITLE
SRR: Fixed stress/virial calculations for rigid bodies

### DIFF
--- a/libhoomd/cuda/RigidData.cuh
+++ b/libhoomd/cuda/RigidData.cuh
@@ -116,9 +116,11 @@ cudaError_t gpu_compute_virial_correction_end(Scalar *d_net_virial,
                                               const unsigned int virial_pitch,
                                               const Scalar4 *d_net_force,
                                               const Scalar4 *d_oldpos,
+                                              const Scalar4 *d_body_com, // SRR: passing body COM for minimum image in stress calc
                                               const Scalar4 *d_oldvel,
                                               const Scalar4 *d_vel,
                                               const unsigned int *d_body,
+                                              const BoxDim& box, // SRR: passing box for minimum image in stress calculations
                                               Scalar deltaT,
                                               unsigned int N);
 

--- a/libhoomd/data_structures/RigidData.cc
+++ b/libhoomd/data_structures/RigidData.cc
@@ -92,15 +92,11 @@ RigidData::RigidData(boost::shared_ptr<ParticleData> particle_data)
 
     // save the execution configuration
     m_exec_conf = m_pdata->getExecConf();
-
-    // connect to global particle number change signal
-    m_sort_connection = m_pdata->connectGlobalParticleNumberChange(bind(&RigidData::slotGlobalParticleNumberChange, this));
     }
 
 RigidData::~RigidData()
     {
     m_sort_connection.disconnect();
-    m_global_particle_num_connection.disconnect();
     }
 
 
@@ -1110,13 +1106,16 @@ void RigidData::computeVirialCorrectionEndCPU(Scalar deltaT)
     {
     // get access to the particle data
     ArrayHandle<Scalar4> h_vel(m_pdata->getVelocities(), access_location::host, access_mode::read);
-    ArrayHandle<unsigned int> h_body(m_pdata->getBodies(), access_location::host, access_mode::read);
     ArrayHandle<Scalar4> h_oldpos(m_particle_oldpos, access_location::host, access_mode::read);
     ArrayHandle<Scalar4> h_oldvel(m_particle_oldvel, access_location::host, access_mode::read);
+    // body data: bodyId's of particles and images of bodies
+    ArrayHandle<unsigned int> h_body(m_pdata->getBodies(), access_location::host, access_mode::read);
 
     ArrayHandle<Scalar> h_net_virial( m_pdata->getNetVirial(), access_location::host, access_mode::readwrite);
     unsigned int virial_pitch = m_pdata->getNetVirial().getPitch();
     ArrayHandle<Scalar4> h_net_force( m_pdata->getNetForce(), access_location::host, access_mode::read);
+
+    BoxDim box = m_pdata->getBox(); // SRR: box for minimum images
 
     // loop through all the particles and compute the virial correction to each one
     for (unsigned int i = 0; i < m_pdata->getN(); i++)
@@ -1128,17 +1127,24 @@ void RigidData::computeVirialCorrectionEndCPU(Scalar deltaT)
             Scalar mass = h_vel.data[i].w;
             Scalar4 old_vel = h_oldvel.data[i];
             Scalar4 old_pos = h_oldpos.data[i];
+            Scalar3 o_p = make_scalar3(old_pos.x,old_pos.y,old_pos.z); // SRR: for relative position w.r.t. COM
+            unsigned int bodyIdx = h_body.data[i]; // SRR: Body index to retrive COM
+            Scalar3 bodyCOM = getBodyCOM(bodyIdx); // SRR: Body COM
+
+            Scalar3 rawdr = make_scalar3(o_p.x-bodyCOM.x, o_p.y-bodyCOM.y, o_p.z-bodyCOM.z); // SRR: relative particle pos w.r.t. COM
+            Scalar3 dr = box.minImage(rawdr); // SRR: minimum image of relative particle pos w.r.t. COM
+
             Scalar3 fc;
             fc.x = mass * (h_vel.data[i].x - old_vel.x) / deltaT - h_net_force.data[i].x;
             fc.y = mass * (h_vel.data[i].y - old_vel.y) / deltaT - h_net_force.data[i].y;
             fc.z = mass * (h_vel.data[i].z - old_vel.z) / deltaT - h_net_force.data[i].z;
 
-            h_net_virial.data[0*virial_pitch+i] += old_pos.x * fc.x;
-            h_net_virial.data[1*virial_pitch+i] += old_pos.x * fc.y;
-            h_net_virial.data[2*virial_pitch+i] += old_pos.x * fc.z;
-            h_net_virial.data[3*virial_pitch+i] += old_pos.y * fc.y;
-            h_net_virial.data[4*virial_pitch+i] += old_pos.y * fc.z;
-            h_net_virial.data[5*virial_pitch+i] += old_pos.z * fc.z;
+            h_net_virial.data[0*virial_pitch+i] += dr.x * fc.x;
+            h_net_virial.data[1*virial_pitch+i] += dr.x * fc.y;
+            h_net_virial.data[2*virial_pitch+i] += dr.x * fc.z;
+            h_net_virial.data[3*virial_pitch+i] += dr.y * fc.y;
+            h_net_virial.data[4*virial_pitch+i] += dr.y * fc.z;
+            h_net_virial.data[5*virial_pitch+i] += dr.z * fc.z;
             }
         }
     }
@@ -1169,21 +1175,28 @@ void RigidData::computeVirialCorrectionEndGPU(Scalar deltaT)
     {
     // get access to the particle data
     ArrayHandle<Scalar4> d_vel(m_pdata->getVelocities(), access_location::device, access_mode::read);
-    ArrayHandle<unsigned int> d_body(m_pdata->getBodies(), access_location::device, access_mode::read);
     ArrayHandle<Scalar4> d_oldpos(m_particle_oldpos, access_location::device, access_mode::read);
     ArrayHandle<Scalar4> d_oldvel(m_particle_oldvel, access_location::device, access_mode::read);
+
+    ArrayHandle<unsigned int> d_body(m_pdata->getBodies(), access_location::device, access_mode::read);
+    ArrayHandle<Scalar4> d_body_com(m_com, access_location::device, access_mode::read);
+    ArrayHandle<int3> d_image(m_pdata->getImages(), access_location::device, access_mode::read);
 
     ArrayHandle<Scalar> d_net_virial( m_pdata->getNetVirial(), access_location::device, access_mode::readwrite);
     unsigned int virial_pitch = m_pdata->getNetVirial().getPitch();
     ArrayHandle<Scalar4> d_net_force( m_pdata->getNetForce(), access_location::device, access_mode::read);
 
+    BoxDim box = m_pdata->getBox();
+
     gpu_compute_virial_correction_end(d_net_virial.data,
                                       virial_pitch,
                                       d_net_force.data,
                                       d_oldpos.data,
+                                      d_body_com.data,
                                       d_oldvel.data,
                                       d_vel.data,
                                       d_body.data,
+                                      box,
                                       deltaT,
                                       m_pdata->getN());
 
@@ -1249,14 +1262,6 @@ void RigidData::takeSnapshot(SnapshotRigidData& snapshot) const
         snapshot.vel[i] = make_scalar3(h_vel.data[i].x,h_vel.data[i].y,h_vel.data[i].z);
         snapshot.angmom[i] = make_scalar3(h_angmom.data[i].x,h_angmom.data[i].y,h_angmom.data[i].z);
         snapshot.body_image[i] = h_body_image.data[i];
-        }
-    }
-
-void RigidData::slotGlobalParticleNumberChange()
-    {
-    if (m_particle_offset.getNumElements() != 0 && m_pdata->getNGlobal() != m_particle_offset.getNumElements())
-        {
-        throw std::runtime_error("Changing particle number with rigid bodies is unsupported.");
         }
     }
 


### PR DESCRIPTION
Fixed stress/virial calculations for rigid bodies to correctly take into account bodies that might span a periodic boundary. Changed "x [dot] F_constraint" to "(x-xCOM) [dot] F_constraint"