### PR TITLE
Automatic citation generation

### DIFF
--- a/libhoomd/python/hoomd_module.cc
+++ b/libhoomd/python/hoomd_module.cc
@@ -454,8 +454,7 @@ BOOST_PYTHON_MODULE(hoomd)
 
     def("abort_mpi", abort_mpi);
 
-    // write out the version information on the module import
-    output_version_info(false);
+    def("output_version_info", &output_version_info);
     def("find_vmd", &find_vmd);
     def("get_hoomd_version", &get_hoomd_version);
 

--- a/libhoomd/utils/HOOMDVersion.cc
+++ b/libhoomd/utils/HOOMDVersion.cc
@@ -57,7 +57,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using namespace std;
 
 /*! \file HOOMDVersion.cc
-    \brief Defines functions for writing compile time version information to the screen.
+    \brief Defines functions for formatting compile time version information as a string.
 
     \ingroup utils
 */
@@ -128,12 +128,12 @@ string output_version_info()
 
     // warn the user if they are running a debug or GPU emulation build
 #ifndef NDEBUG
-    o << endl << "WARNING: This is a DEBUG build, expect slow performance." << endl << endl;
+    o << endl << "WARNING: This is a DEBUG build, expect slow performance." << endl;
 #endif
 
 #ifdef ENABLE_CUDA
 #ifdef _DEVICEEMU
-    o << endl << "WARNING: This is a GPU emulation build, expect extremely slow performance." << endl << endl;
+    o << endl << "WARNING: This is a GPU emulation build, expect extremely slow performance." << endl;
 #endif
 #endif
     return o.str();

--- a/libhoomd/utils/HOOMDVersion.cc
+++ b/libhoomd/utils/HOOMDVersion.cc
@@ -51,6 +51,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "HOOMDVersion.h"
 #include <iostream>
+#include <sstream>
 #include <string>
 
 using namespace std;
@@ -61,93 +62,79 @@ using namespace std;
     \ingroup utils
 */
 
-void output_version_info(bool verbose)
+string output_version_info()
     {
-    #ifdef ENABLE_MPI
-    // only print this on rank zero
-    if (ExecutionConfiguration::getRankGlobal() != 0)
-        return;
-    #endif
-
+    ostringstream o;
     // output the version info that comes from CMake
-    cout << "HOOMD-blue " << HOOMD_VERSION_LONG;
+    o << "HOOMD-blue " << HOOMD_VERSION_LONG;
 
     #ifdef ENABLE_CUDA
-    cout << " CUDA";
+    o << " CUDA";
     #endif
 
     #ifdef SINGLE_PRECISION
-    cout << " SINGLE";
+    o << " SINGLE";
     #else
-    cout << " DOUBLE";
+    o << " DOUBLE";
     #endif
 
     #ifdef ENABLE_MPI
-    cout << " MPI";
+    o << " MPI";
     #endif
 
     #ifdef ENABLE_MPI_CUDA
-    cout << " MPI_CUDA";
+    o << " MPI_CUDA";
     #endif
 
     #ifdef __SSE__
-    cout << " SSE";
+    o << " SSE";
     #endif
 
     #ifdef __SSE2__
-    cout << " SSE2";
+    o << " SSE2";
     #endif
 
     #ifdef __SSE3__
-    cout << " SSE3";
+    o << " SSE3";
     #endif
 
     #ifdef __SSE4_1__
-    cout << " SSE4_1";
+    o << " SSE4_1";
     #endif
 
     #ifdef __SSE4_2__
-    cout << " SSE4_2";
+    o << " SSE4_2";
     #endif
 
     #ifdef __AVX__
-    cout << " AVX";
+    o << " AVX";
     #endif
 
     #ifdef __AVX2__
-    cout << " AVX2";
+    o << " AVX2";
     #endif
 
-    cout << endl;
+    o << endl;
 
     // output the compiled date and copyright information
-    cout << "Compiled: " << COMPILE_DATE << endl;
-    cout << "Copyright 2009-2014 The Regents of the University of Michigan."
-         << endl;
+    o << "Compiled: " << COMPILE_DATE << endl;
+    o << "Copyright 2009-2014 The Regents of the University of Michigan." << endl << endl;
 
     // output the paper citation information
-    cout << "-----" << endl;
-    cout << "All publications and presentations based on HOOMD-blue, including any reports" << endl;
-    cout << "or published results obtained, in whole or in part, with HOOMD-blue, will" << endl;
-    cout << "acknowledge its use according to the terms posted at the time of submission on:" << endl;
-    cout << "http://codeblue.umich.edu/hoomd-blue/citations.html" << endl;
-    cout << endl;
-    cout << "At a minimum, this includes citations of:" << endl;
-    cout << "* http://codeblue.umich.edu/hoomd-blue/" << endl;
-    cout << "and:" << endl;
-    cout << "* Joshua A. Anderson, Chris D. Lorenz, and Alex Travesset - 'General" << endl;
-    cout << "  Purpose Molecular Dynamics Fully Implemented on Graphics Processing" << endl;
-    cout << "  Units', Journal of Computational Physics 227 (2008) 5342-5359" << endl;
-    cout << "-----" << endl;
+    o << "All publications and presentations based on HOOMD-blue, including any reports" << endl;
+    o << "or published results obtained, in whole or in part, with HOOMD-blue, will" << endl;
+    o << "acknowledge its use according to the terms posted at the time of submission on:" << endl;
+    o << "http://codeblue.umich.edu/hoomd-blue/citations.html" << endl;
 
     // warn the user if they are running a debug or GPU emulation build
 #ifndef NDEBUG
-    cout << "WARNING: This is a DEBUG build, expect slow performance." << endl;
+    o << endl << "WARNING: This is a DEBUG build, expect slow performance." << endl << endl;
 #endif
 
 #ifdef ENABLE_CUDA
 #ifdef _DEVICEEMU
-    cout << "WARNING: This is a GPU emulation build, expect extremely slow performance." << endl;
+    o << endl << "WARNING: This is a GPU emulation build, expect extremely slow performance." << endl << endl;
 #endif
 #endif
+    return o.str();
     }

--- a/libhoomd/utils/HOOMDVersion.h.in
+++ b/libhoomd/utils/HOOMDVersion.h.in
@@ -67,6 +67,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define HOOMD_VERSION_PATCH ${HOOMD_VERSION_PATCH}
 
 #include "ExecutionConfiguration.h"
+#include <string>
 
 /*! \file HOOMDVersion.h.in
 	\brief Functions and variables for printing compile time build information of HOOMD
@@ -76,9 +77,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	\ingroup utils
 */
 
-//! Prints version information to cout
-/*! \param verbose Enables verbose output including details on compile time options
-*/
-void output_version_info(bool verbose);
+//! Formats the HOOMD version info header as string
+std::string output_version_info();
 
 #endif

--- a/python-module/hoomd_script/__init__.py
+++ b/python-module/hoomd_script/__init__.py
@@ -99,6 +99,9 @@ from hoomd_script import cite;
 # simulations using HOOMD. This python module is designed to be imported
 # into python with "from hoomd_script import *"
 
+# output the version info on import
+globals.msg.notice(1, hoomd.output_version_info())
+
 # create the bibliography on import with HOOMD citations that are always needed
 cite._ensure_global_bib()
 

--- a/python-module/hoomd_script/__init__.py
+++ b/python-module/hoomd_script/__init__.py
@@ -102,9 +102,6 @@ from hoomd_script import cite;
 # output the version info on import
 globals.msg.notice(1, hoomd.output_version_info())
 
-# create the bibliography on import with HOOMD citations that are always needed
-cite._ensure_global_bib()
-
 ## \internal
 # \brief Internal python variable
 

--- a/python-module/hoomd_script/__init__.py
+++ b/python-module/hoomd_script/__init__.py
@@ -102,6 +102,9 @@ from hoomd_script import cite;
 # output the version info on import
 globals.msg.notice(1, hoomd.output_version_info())
 
+# ensure creation of global bibliography to print HOOMD base citations
+cite._ensure_global_bib()
+
 ## \internal
 # \brief Internal python variable
 
@@ -210,9 +213,6 @@ def run(tsteps, profile=False, limit_hours=None, limit_multiple=1, callback_peri
     if not init.is_initialized():
         globals.msg.error("Cannot run before initialization\n");
         raise RuntimeError('Error running');
-
-    # save the bibliography at run time
-    cite._ensure_global_bib().save()
 
     if globals.integrator is None:
         globals.msg.warning("Starting a run without an integrator set");

--- a/python-module/hoomd_script/__init__.py
+++ b/python-module/hoomd_script/__init__.py
@@ -90,6 +90,7 @@ from hoomd_script import hoomd;
 from hoomd_script import compute;
 from hoomd_script import charge;
 from hoomd_script import comm;
+from hoomd_script import cite;
 
 ## \package hoomd_script
 # \brief Base module for the user-level scripting API
@@ -97,6 +98,9 @@ from hoomd_script import comm;
 # hoomd_script provides a very high level user interface for executing
 # simulations using HOOMD. This python module is designed to be imported
 # into python with "from hoomd_script import *"
+
+# create the bibliography on import with HOOMD citations that are always needed
+cite._ensure_global_bib()
 
 ## \internal
 # \brief Internal python variable

--- a/python-module/hoomd_script/__init__.py
+++ b/python-module/hoomd_script/__init__.py
@@ -214,6 +214,9 @@ def run(tsteps, profile=False, limit_hours=None, limit_multiple=1, callback_peri
         globals.msg.error("Cannot run before initialization\n");
         raise RuntimeError('Error running');
 
+    # save the bibliography at run time
+    cite._ensure_global_bib().save()
+
     if globals.integrator is None:
         globals.msg.warning("Starting a run without an integrator set");
     else:

--- a/python-module/hoomd_script/cite.py
+++ b/python-module/hoomd_script/cite.py
@@ -331,11 +331,8 @@ class bibliography(object):
     def __init__(self):
         self.entries = {}
         self.autosave = False
-        self.first_save = True
         self.updated = False
-        self.force = False
         self.file = 'hoomd.bib'
-        self.overwrite = True
     ## \var entries
     # \internal
     # \brief Dictionary of citations
@@ -348,17 +345,9 @@ class bibliography(object):
     # \internal
     # \brief Flag marking if the bibliography has been updated since the last save
 
-    ## \var force
-    # \internal
-    # \brief Flag to force bibliography to be written to file
-
     ## \var file
     # \internal
     # \brief File name to use to save the bibliography
-
-    ## \var overwrite
-    # \internal
-    # \brief Flag allowing the current bibliography file to be overwritten
 
     ## \internal
     # \brief Adds a citation, ensuring each key is only saved once
@@ -369,7 +358,7 @@ class bibliography(object):
             entry = [entry]
 
         # parse unique sets of features out of attached citations
-        features = {}
+        citations = {}
         for e in entry:
             e.validate()
             self.entries[e.cite_key] = e
@@ -378,10 +367,10 @@ class bibliography(object):
             if log_str is not None: # if display is enabled and log returns an output
                 # if a feature is specified, we try to group them together into logical sets
                 if e.feature is not None:
-                    if e.feature not in features:
-                        features[e.feature] = [log_str]
+                    if e.feature not in citations:
+                        citations[e.feature] = [log_str]
                     else:
-                        features[e.feature] += [log_str]
+                        citations[e.feature] += [log_str]
                 else: # otherwise, just print the feature without any decoration
                     cite_str = '-'*5 + '\n'
                     cite_str += 'Read and cite the following:\n'
@@ -391,11 +380,11 @@ class bibliography(object):
                     globals.msg.notice(1, cite_str)
 
         # print each feature set together
-        for f in features:
+        for feature in citations:
             cite_str = '-'*5 + '\n'
-            cite_str += 'You are using %s. Read and cite the following:\n' % f
-            cite_str += 'and\n'.join(features[f])
-            if len(features[f]) > 1:
+            cite_str += 'You are using %s. Read and cite the following:\n' % feature
+            cite_str += 'and\n'.join(citations[feature])
+            if len(citations[feature]) > 1:
                 cite_str += 'You can save these citations to file using cite.save().\n'
             else:
                 cite_str += 'You can save this citation to file using cite.save().\n'
@@ -404,25 +393,16 @@ class bibliography(object):
 
         # after adding, we need to update the file
         self.updated = True
-    
+
+        # if autosaving is enabled, bibliography should try to save itself to file
+        if self.autosave:
+            self.save()
+
     ## \internal
     # \brief Saves the bibliography to file
-    #
-    # If the %bibliography file already exists, and overwrite is set to false, an error will be raised.
-    # This is done because the BibTeX file cannot not be appended to (behavior of analyze.log), or else duplicated
-    # citation keys would be recorded.
     def save(self):
         if not self.should_save():
             return
-
-        # if the file already exists, notify the user if overwriting is on, or abort otherwise
-        if os.path.isfile(self.file):
-            if self.overwrite:
-                globals.msg.notice(3, 'cite.save: bibliography file %s already exists, overwriting.\n' % self.file)
-            # raise an error if autosaving for the first time and name conflict, or for any forced save
-            elif (self.autosave and self.first_save) or not self.autosave:
-                globals.msg.error('cite.save: bibliography file %s already exists, cannot save\n' % self.file)
-                raise RuntimeError('Cannot write bibliography')
 
         # dump all BibTeX entries to file (in no particular order)
         f = open(self.file, 'w')
@@ -434,29 +414,18 @@ class bibliography(object):
 
         # after saving, we no longer need updating
         self.updated = False
-        # toggle off first save so that overwriting is now allowed
-        if self.autosave and self.first_save:
-            self.first_save = False
 
     ## \internal
     # \brief Set parameters for saving the %bibliography file
     # \param file %Bibliography file name
     # \param autosave Flag to have %bibliography automatically saved as needed during run
-    # \param overwrite Flag to overwrite an existing %bibliography file
     #
-    # If \a autosave is true, the bibliography will be automatically generated and updated each time run() is called.
-    def set_params(self, file=None, autosave=None, overwrite=None):
+    # If \a autosave is true, the bibliography will be automatically saved to file each time a new citation is added.
+    def set_params(self, file=None, autosave=None):
         if file is not None:
             self.file = file
         if autosave is not None:
             self.autosave = autosave
-        if overwrite is not None:
-            self.overwrite = overwrite
-
-    ## \internal
-    # \brief Set a flag to force the bibliography to be saved
-    def force_save(self):
-        self.force = True
 
     ## \internal
     # \brief Determines if the current rank should save the bibliography file
@@ -465,13 +434,8 @@ class bibliography(object):
         if len(self.entries) == 0 or comm.get_rank() != 0:
             return False
 
-        # if a save is forced (one time), toggle off and always return true
-        if self.force:
-            force = False
-            return True
-
-        # otherwise, check for auto saving and bibliography is updated
-        return (self.autosave and self.updated)
+        # otherwise, check if the bibliography has been updated since last save
+        return self.updated
 
 ## \internal
 # \brief Ensures that the global bibliography is properly initialized
@@ -506,36 +470,23 @@ def _ensure_global_bib():
 ## Saves the automatically generated %bibliography to a BibTeX file
 #
 # \param file File name for the saved %bibliography
-# \param overwrite Flag to allow %bibliography file to be overwritten if it already exists
-# \param force Flag to force generation of the bibliography immediately
 #
-# If the BibTeX file already exists, and \a overwrite is set to false, an error will be raised.
-# This is done because the BibTeX file cannot not be appended to (behavior of analyze.log), or duplicated
-# citation keys would be recorded.
-#
-# If \a force is true, the BibTeX file will be written immediately. By default, the %bibliography
-# will check for new entries and (re-)generate each time that run() is called to ensure that all citations have been
-# included. In this case, the BibTeX file name only needs to be specified once, and when \a overwrite is false, multiple
-# calls to run() are permitted to overwrite \a file after ensuring that \a file did not exist before run() was called
-# the first time.
+# After save() is called for the first time, the %bibliography will (re-)generate each time that a new feature is added
+# to ensure that all citations have been included. If \a file already exists, it will be overwritten.
 #
 # \b Examples
 # \code
-# cite.save(file='citenow.bib', force=True)
-# cite.save(file='citeonrun.bib', overwrite=False)
+# cite.save()
+# cite.save(file='cite.bib')
 # \endcode
-def save(file='hoomd.bib', overwrite=True, force=False):
+def save(file='hoomd.bib'):
     util.print_status_line()
     
     # force a bibliography to exist
     bib = _ensure_global_bib()
 
     # update the bibliography save parameters
-    bib.set_params(file=file, overwrite=overwrite)
+    bib.set_params(file=file, autosave=True)
 
-    # force save, or else mark to save later
-    if force:
-        bib.force_save()
-        bib.save()
-    else:
-        bib.set_params(autosave=True)
+    # save to file
+    bib.save()

--- a/python-module/hoomd_script/cite.py
+++ b/python-module/hoomd_script/cite.py
@@ -1,0 +1,279 @@
+# -- start license --
+# Highly Optimized Object-oriented Many-particle Dynamics -- Blue Edition
+# (HOOMD-blue) Open Source Software License Copyright 2009-2014 The Regents of
+# the University of Michigan All rights reserved.
+
+# HOOMD-blue may contain modifications ("Contributions") provided, and to which
+# copyright is held, by various Contributors who have granted The Regents of the
+# University of Michigan the right to modify and/or distribute such Contributions.
+
+# You may redistribute, use, and create derivate works of HOOMD-blue, in source
+# and binary forms, provided you abide by the following conditions:
+
+# * Redistributions of source code must retain the above copyright notice, this
+# list of conditions, and the following disclaimer both in the code and
+# prominently in any materials provided with the distribution.
+
+# * Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions, and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+
+# * All publications and presentations based on HOOMD-blue, including any reports
+# or published results obtained, in whole or in part, with HOOMD-blue, will
+# acknowledge its use according to the terms posted at the time of submission on:
+# http://codeblue.umich.edu/hoomd-blue/citations.html
+
+# * Any electronic documents citing HOOMD-Blue will link to the HOOMD-Blue website:
+# http://codeblue.umich.edu/hoomd-blue/
+
+# * Apart from the above required attributions, neither the name of the copyright
+# holder nor the names of HOOMD-blue's contributors may be used to endorse or
+# promote products derived from this software without specific prior written
+# permission.
+
+# Disclaimer
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND/OR ANY
+# WARRANTIES THAT THIS SOFTWARE IS FREE OF INFRINGEMENT ARE DISCLAIMED.
+
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -- end license --
+
+# Maintainer: mphoward / All Developers are free to add commands for new features
+
+from hoomd_script import util
+from hoomd_script import globals
+import textwrap
+import os
+
+## \package hoomd_script.cite
+# \brief Commands to support automatic citation generation
+
+## \internal
+# 
+class _citation(object):
+    def __init__(self, cite_key, feature, author):
+        self.cite_key = cite_key
+        self.feature = feature
+        
+        # author requires special handling for I/O
+        self.author = None
+        if author is not None:
+            if not isinstance(author, (list,tuple)):
+                self.author = [author]
+            else:
+                self.author = author
+        
+        self.required_entries = []
+        self.bibtex_type = None
+        
+        for key in _citation.standard_keys:
+            setattr(self,key,None)
+
+        # doi and url require special handling for I/O
+        self.doi = None
+        self.url = None
+    
+    def log(self):
+        wrapper = textwrap.TextWrapper(initial_indent = '* ', subsequent_indent = '  ', width = 80)
+        
+        print '-'*5
+        if self.feature is not None:
+            print textwrap.fill('You are using %s. Read and cite the following:' % self.feature)
+        else:
+            print textwrap.fill('Read and cite the following:')
+        
+        out = ''
+        if self.author is not None:
+            out += self.format_authors(True)
+            out += '. '
+        
+        out += self.fancy_print()
+        
+        out += '.'
+        
+        print wrapper.fill(out)
+        print '-'*5
+    
+    def fancy_print(self):
+        globals.msg.error('Bug in hoomd_script.cite: each deriving class must implement its own fancy_print\n')
+        raise RuntimeError()
+    
+    def validate(self):
+        for entry in self.required_entries:
+            if getattr(self,entry) is None:
+                globals.msg.error('Bug in hoomd_script.cite: required field %s not set, please report\n' % entry)
+                raise RuntimeError()
+        
+    def format_authors(self, fancy=False):
+        if self.author is None:
+            return
+        
+        if len(self.author) > 1:
+            if fancy:
+                return '%s, and %s' % (', '.join(self.author[:-1]), self.author[-1])
+            else:
+                return ' and '.join(self.author)
+        else:
+            return self.author[0]
+    
+    def bibtex(self):
+        if self.bibtex_type is None:
+            globals.msg.error('Bug in hoomd_script.cite: BibTeX record type must be set, please report\n')
+            raise RuntimeError()
+            
+        lines = ['@%s{%s,' % (self.bibtex_type, self.cite_key)]
+        if self.author is not None:
+            lines += ['  author = {%s},' % self.format_authors(False)]
+            
+        for key in _citation.standard_keys:
+            val = getattr(self, key)
+            if getattr(self, key) is not None:
+                lines += ['  %s = {%s},' % (key, val)]
+        
+        # doi requires special handling
+        if self.doi is not None:
+            lines += ['  doi = {%s},' % self.doi, '  url = {http://dx.doi.org/%s},' % self.doi]
+        
+        # add note based on the feature if a note has not been set
+        if self.feature is not None and self.note is None:
+            lines += ['  note = {HOOMD-blue feature: %s},' % self.feature]
+        
+        # remove trailing comma
+        lines[-1] = lines[-1][:-1]
+        
+        #close off record
+        lines += ['}']
+        
+        return '\n'.join(lines)
+_citation.standard_keys = ['address','annote','booktitle','chapter','crossref','edition','editor','howpublished',
+                           'institution', 'journal','key','month','note','number','organization','pages','publisher',
+                           'school','series','title', 'type','volume','year']
+
+
+## Article BibTeX entry
+# 
+class article(_citation):
+    def __init__(self, cite_key, author, title, journal, year, volume, number=None, pages=None, month=None, note=None, key=None, doi=None, feature=None, display=True):
+        _citation.__init__(self, cite_key, feature, author)
+        
+        self.required_entries = ['author', 'title', 'journal', 'year', 'volume', 'pages']
+        self.bibtex_type = 'article'
+        
+        self.title = title
+        self.journal = journal
+        self.year = year
+        self.volume = volume
+        self.number = number
+        self.pages = pages
+        self.month = month
+        self.note = note
+        self.key = key
+        self.doi = doi
+        
+        # attach to the global bibliography
+        _ensure_global_bib().add(self)
+        
+        if display:
+            self.log()
+    
+    def fancy_print(self):
+        return '"%s", %s %s (%s) %s' % (self.title, self.journal, str(self.volume), str(self.year), str(self.pages))
+
+## Miscellaneous BibTeX entry
+#
+class misc(_citation):
+    def __init__(self, cite_key, author=None, title=None, howpublished=None, year=None, month=None, note=None, key=None, feature=None, display=True):
+        _citation.__init__(self, cite_key, feature, author)
+        self.required_entries = []
+        self.bibtex_type = 'misc'
+        
+        self.title = title
+        self.howpublished = howpublished
+        self.year = year
+        self.month = month
+        self.note = note
+        self.key = key
+        
+        if display:
+            self.log()
+        
+    def fancy_print(self):
+        out = ''
+        if self.title is not None:
+            out += '"%s", ' % self.title
+        if self.howpublished is not None:
+            out += self.howpublished
+        if len(out) > 0:
+            out += ' (%s)' % str(year)
+        return out
+
+## Bibliography
+#
+class bibliography(object):
+    def __init__(self):
+        self.entries = {}
+    
+    def add(self, entry):
+        entry.validate()
+        
+        self.entries[entry.cite_key] = entry
+    
+    def save(self, file):
+        if len(self.entries) == 0:
+            globals.msg.warning('Empty bibliography generated, not saving anything to file.\n')
+            return
+            
+        if os.path.isfile(file):
+            globals.msg.warning('Bibliography file %s already exists, overwriting.\n' % file)
+        
+        f = open(file, 'w')
+        f.write('% This BibTeX file was automatically generated from HOOMD-blue\n')
+        f.write('% Encoding: UTF-8\n\n')
+        for entry in self.entries:
+            f.write(self.entries[entry].bibtex() + '\n\n')
+        f.close()
+
+## \internal
+# \brief Ensures that the global bibliography is properly initialized
+# \returns Global bibliography
+def _ensure_global_bib():
+    if globals.bib is None:
+        globals.bib = bibliography()
+    
+        # the hoomd bibliography always includes the following citations
+        hoomd = article(cite_key = 'anderson2008',
+                        author = ['J A Anderson','C D Lorenz','A Travesset'],
+                        title = 'General purpose molecular dynamics simulations fully implemented on graphics processing units',
+                        journal = 'Journal of Computational Physics',
+                        volume = 227,
+                        number = 10,
+                        pages = '5342--5359',
+                        year = 2008,
+                        month = 'may',
+                        doi = '10.1016/j.jcp.2008.01.047',
+                        display = False)
+        hoomd_web = misc(cite_key = 'hoomdweb', howpublished = 'http://codeblue.umich.edu/hoomd-blue', display = False)
+                    
+        globals.bib.add(hoomd)
+        globals.bib.add(hoomd_web)
+    return globals.bib
+
+## Wrapper to write global bibliography to file
+#
+def save_bib(file='hoomd.bib'):
+    util.print_status_line()
+    
+    if globals.bib is not None:
+        globals.bib.save(file)
+    else:
+        globals.msg.warning('No bibliography generated, not saving anything to file.\n')
+    

--- a/python-module/hoomd_script/cite.py
+++ b/python-module/hoomd_script/cite.py
@@ -360,6 +360,7 @@ class bibliography(object):
                     cite_str = '-'*5 + '\n'
                     cite_str += 'Read and cite the following:\n'
                     cite_str += log_str
+                    cite_str += 'You can save this citation to file using cite.save().\n'
                     cite_str += '-'*5 + '\n'
                     globals.msg.notice(1, cite_str)
 
@@ -368,6 +369,10 @@ class bibliography(object):
             cite_str = '-'*5 + '\n'
             cite_str += 'You are using %s. Read and cite the following:\n' % f
             cite_str += 'and\n'.join(features[f])
+            if len(features[f]) > 1:
+                cite_str += 'You can save these citations to file using cite.save().\n'
+            else:
+                cite_str += 'You can save this citation to file using cite.save().\n'
             cite_str += '-'*5 + '\n'
             globals.msg.notice(1, cite_str)
     

--- a/python-module/hoomd_script/globals.py
+++ b/python-module/hoomd_script/globals.py
@@ -107,6 +107,9 @@ options = None;
 # messages
 msg = hoomd.Messenger();
 
+## Global bibliography
+bib = None;
+
 ## \internal
 # \brief Clears all global variables to default values
 # \details called by hoomd_script.reset()
@@ -126,3 +129,4 @@ def clear():
     thermos = [];
     group_all = None;
     sorter = None;
+    bib = None;

--- a/python-module/hoomd_script/globals.py
+++ b/python-module/hoomd_script/globals.py
@@ -115,7 +115,7 @@ bib = None;
 # \details called by hoomd_script.reset()
 def clear():
     global system_definition, system, forces, constraint_forces, external_forces, integration_methods, integrator, neighbor_list, loggers, thermos;
-    global sorter, group_all, exec_conf;
+    global sorter, group_all, exec_conf, bib;
 
     system_definition = None;
     system = None;

--- a/python-module/hoomd_script/integrate.py
+++ b/python-module/hoomd_script/integrate.py
@@ -101,6 +101,7 @@ from hoomd_script import util;
 from hoomd_script import variant;
 from hoomd_script import init;
 from hoomd_script import comm;
+from hoomd_script import cite;
 
 ## \internal
 # \brief Base class for integrators
@@ -1005,6 +1006,19 @@ class nve_rigid(_integration_method):
     # \endcode
     def __init__(self, group):
         util.print_status_line();
+        
+        # register the citation
+        cite.article(cite_key='nguyen2011',
+                     author=['T D Nguyen', 'C L Phillips', 'J A Anderson', 'S C Glotzer'],
+                     title='Rigid body constraints realized in massively-parallel molecular dynamics on graphics processing units',
+                     journal='Computer Physics Communications',
+                     volume=182,
+                     number=11,
+                     pages='2307--2313',
+                     month='Jun',
+                     year='2011',
+                     doi='10.1016/j.cpc.2011.06.005',
+                     feature='rigid body integration')
 
         # Error out in MPI simulations
         if (hoomd.is_MPI_available()):
@@ -1053,6 +1067,19 @@ class nvt_rigid(_integration_method):
     # \endcode
     def __init__(self, group, T, tau):
         util.print_status_line();
+
+        # register the citation
+        cite.article(cite_key='nguyen2011',
+                     author=['T D Nguyen', 'C L Phillips', 'J A Anderson', 'S C Glotzer'],
+                     title='Rigid body constraints realized in massively-parallel molecular dynamics on graphics processing units',
+                     journal='Computer Physics Communications',
+                     volume=182,
+                     number=11,
+                     pages='2307--2313',
+                     month='Jun',
+                     year='2011',
+                     doi='10.1016/j.cpc.2011.06.005',
+                     feature='rigid body integration')
 
         # Error out in MPI simulations
         if (hoomd.is_MPI_available()):
@@ -1147,6 +1174,19 @@ class bdnvt_rigid(_integration_method):
     # \endcode
     def __init__(self, group, T, seed=0, gamma_diam=False):
         util.print_status_line();
+
+        # register the citation
+        cite.article(cite_key='nguyen2011',
+                     author=['T D Nguyen', 'C L Phillips', 'J A Anderson', 'S C Glotzer'],
+                     title='Rigid body constraints realized in massively-parallel molecular dynamics on graphics processing units',
+                     journal='Computer Physics Communications',
+                     volume=182,
+                     number=11,
+                     pages='2307--2313',
+                     month='Jun',
+                     year='2011',
+                     doi='10.1016/j.cpc.2011.06.005',
+                     feature='rigid body integration')
 
         # Error out in MPI simulations
         if (hoomd.is_MPI_available()):
@@ -1259,6 +1299,19 @@ class npt_rigid(_integration_method):
     def __init__(self, group, T, tau, P, tauP):
         util.print_status_line();
 
+        # register the citation
+        cite.article(cite_key='nguyen2011',
+                     author=['T D Nguyen', 'C L Phillips', 'J A Anderson', 'S C Glotzer'],
+                     title='Rigid body constraints realized in massively-parallel molecular dynamics on graphics processing units',
+                     journal='Computer Physics Communications',
+                     volume=182,
+                     number=11,
+                     pages='2307--2313',
+                     month='Jun',
+                     year='2011',
+                     doi='10.1016/j.cpc.2011.06.005',
+                     feature='rigid body integration')
+
         # Error out in MPI simulations
         if (hoomd.is_MPI_available()):
             if globals.system_definition.getParticleData().getDomainDecomposition():
@@ -1348,6 +1401,19 @@ class nph_rigid(_integration_method):
     # \endcode
     def __init__(self, group, P, tauP):
         util.print_status_line();
+
+        # register the citation
+        cite.article(cite_key='nguyen2011',
+                     author=['T D Nguyen', 'C L Phillips', 'J A Anderson', 'S C Glotzer'],
+                     title='Rigid body constraints realized in massively-parallel molecular dynamics on graphics processing units',
+                     journal='Computer Physics Communications',
+                     volume=182,
+                     number=11,
+                     pages='2307--2313',
+                     month='Jun',
+                     year='2011',
+                     doi='10.1016/j.cpc.2011.06.005',
+                     feature='rigid body integration')
 
         # Error out in MPI simulations
         if (hoomd.is_MPI_available()):
@@ -1534,6 +1600,19 @@ class mode_minimize_rigid_fire(_integrator):
     #   - <i>optional</i>: defaults to 1e-5
     def __init__(self, group, dt, Nmin=None, finc=None, fdec=None, alpha_start=None, falpha=None, ftol = None, wtol=None, Etol= None):
         util.print_status_line();
+
+        # register the citation
+        cite.article(cite_key='nguyen2011',
+                     author=['T D Nguyen', 'C L Phillips', 'J A Anderson', 'S C Glotzer'],
+                     title='Rigid body constraints realized in massively-parallel molecular dynamics on graphics processing units',
+                     journal='Computer Physics Communications',
+                     volume=182,
+                     number=11,
+                     pages='2307--2313',
+                     month='Jun',
+                     year='2011',
+                     doi='10.1016/j.cpc.2011.06.005',
+                     feature='rigid body integration')
 
         # initialize base class
         _integrator.__init__(self);

--- a/python-module/hoomd_script/integrate.py
+++ b/python-module/hoomd_script/integrate.py
@@ -1008,17 +1008,18 @@ class nve_rigid(_integration_method):
         util.print_status_line();
         
         # register the citation
-        cite.article(cite_key='nguyen2011',
-                     author=['T D Nguyen', 'C L Phillips', 'J A Anderson', 'S C Glotzer'],
-                     title='Rigid body constraints realized in massively-parallel molecular dynamics on graphics processing units',
-                     journal='Computer Physics Communications',
-                     volume=182,
-                     number=11,
-                     pages='2307--2313',
-                     month='Jun',
-                     year='2011',
-                     doi='10.1016/j.cpc.2011.06.005',
-                     feature='rigid body integration')
+        c = cite.article(cite_key='nguyen2011',
+                         author=['T D Nguyen', 'C L Phillips', 'J A Anderson', 'S C Glotzer'],
+                         title='Rigid body constraints realized in massively-parallel molecular dynamics on graphics processing units',
+                         journal='Computer Physics Communications',
+                         volume=182,
+                         number=11,
+                         pages='2307--2313',
+                         month='Jun',
+                         year='2011',
+                         doi='10.1016/j.cpc.2011.06.005',
+                         feature='rigid body integration')
+        cite._ensure_global_bib().add(c)
 
         # Error out in MPI simulations
         if (hoomd.is_MPI_available()):
@@ -1069,17 +1070,18 @@ class nvt_rigid(_integration_method):
         util.print_status_line();
 
         # register the citation
-        cite.article(cite_key='nguyen2011',
-                     author=['T D Nguyen', 'C L Phillips', 'J A Anderson', 'S C Glotzer'],
-                     title='Rigid body constraints realized in massively-parallel molecular dynamics on graphics processing units',
-                     journal='Computer Physics Communications',
-                     volume=182,
-                     number=11,
-                     pages='2307--2313',
-                     month='Jun',
-                     year='2011',
-                     doi='10.1016/j.cpc.2011.06.005',
-                     feature='rigid body integration')
+        c = cite.article(cite_key='nguyen2011',
+                         author=['T D Nguyen', 'C L Phillips', 'J A Anderson', 'S C Glotzer'],
+                         title='Rigid body constraints realized in massively-parallel molecular dynamics on graphics processing units',
+                         journal='Computer Physics Communications',
+                         volume=182,
+                         number=11,
+                         pages='2307--2313',
+                         month='Jun',
+                         year='2011',
+                         doi='10.1016/j.cpc.2011.06.005',
+                         feature='rigid body integration')
+        cite._ensure_global_bib().add(c)
 
         # Error out in MPI simulations
         if (hoomd.is_MPI_available()):
@@ -1176,17 +1178,18 @@ class bdnvt_rigid(_integration_method):
         util.print_status_line();
 
         # register the citation
-        cite.article(cite_key='nguyen2011',
-                     author=['T D Nguyen', 'C L Phillips', 'J A Anderson', 'S C Glotzer'],
-                     title='Rigid body constraints realized in massively-parallel molecular dynamics on graphics processing units',
-                     journal='Computer Physics Communications',
-                     volume=182,
-                     number=11,
-                     pages='2307--2313',
-                     month='Jun',
-                     year='2011',
-                     doi='10.1016/j.cpc.2011.06.005',
-                     feature='rigid body integration')
+        c = cite.article(cite_key='nguyen2011',
+                         author=['T D Nguyen', 'C L Phillips', 'J A Anderson', 'S C Glotzer'],
+                         title='Rigid body constraints realized in massively-parallel molecular dynamics on graphics processing units',
+                         journal='Computer Physics Communications',
+                         volume=182,
+                         number=11,
+                         pages='2307--2313',
+                         month='Jun',
+                         year='2011',
+                         doi='10.1016/j.cpc.2011.06.005',
+                         feature='rigid body integration')
+        cite._ensure_global_bib().add(c)
 
         # Error out in MPI simulations
         if (hoomd.is_MPI_available()):
@@ -1300,7 +1303,7 @@ class npt_rigid(_integration_method):
         util.print_status_line();
 
         # register the citation
-        cite.article(cite_key='nguyen2011',
+        c = cite.article(cite_key='nguyen2011',
                      author=['T D Nguyen', 'C L Phillips', 'J A Anderson', 'S C Glotzer'],
                      title='Rigid body constraints realized in massively-parallel molecular dynamics on graphics processing units',
                      journal='Computer Physics Communications',
@@ -1311,6 +1314,7 @@ class npt_rigid(_integration_method):
                      year='2011',
                      doi='10.1016/j.cpc.2011.06.005',
                      feature='rigid body integration')
+        cite._ensure_global_bib().add(c)
 
         # Error out in MPI simulations
         if (hoomd.is_MPI_available()):
@@ -1403,7 +1407,7 @@ class nph_rigid(_integration_method):
         util.print_status_line();
 
         # register the citation
-        cite.article(cite_key='nguyen2011',
+        c = cite.article(cite_key='nguyen2011',
                      author=['T D Nguyen', 'C L Phillips', 'J A Anderson', 'S C Glotzer'],
                      title='Rigid body constraints realized in massively-parallel molecular dynamics on graphics processing units',
                      journal='Computer Physics Communications',
@@ -1414,6 +1418,7 @@ class nph_rigid(_integration_method):
                      year='2011',
                      doi='10.1016/j.cpc.2011.06.005',
                      feature='rigid body integration')
+        cite._ensure_global_bib().add(c)
 
         # Error out in MPI simulations
         if (hoomd.is_MPI_available()):
@@ -1602,7 +1607,7 @@ class mode_minimize_rigid_fire(_integrator):
         util.print_status_line();
 
         # register the citation
-        cite.article(cite_key='nguyen2011',
+        c = cite.article(cite_key='nguyen2011',
                      author=['T D Nguyen', 'C L Phillips', 'J A Anderson', 'S C Glotzer'],
                      title='Rigid body constraints realized in massively-parallel molecular dynamics on graphics processing units',
                      journal='Computer Physics Communications',
@@ -1613,6 +1618,7 @@ class mode_minimize_rigid_fire(_integrator):
                      year='2011',
                      doi='10.1016/j.cpc.2011.06.005',
                      feature='rigid body integration')
+        cite._ensure_global_bib().add(c)
 
         # initialize base class
         _integrator.__init__(self);

--- a/python-module/hoomd_script/pair.py
+++ b/python-module/hoomd_script/pair.py
@@ -1843,17 +1843,18 @@ class dpd(pair):
         util.print_status_line();
         
         # register the citation
-        cite.article(cite_key='phillips2011',
-                     author=['C L Phillips', 'J A Anderson', 'S C Glotzer'],
-                     title='Pseudo-random number generation for Brownian Dynamics and Dissipative Particle Dynamics simulations on GPU devices',
-                     journal='Journal of Computational Physics',
-                     volume=230,
-                     number=19,
-                     pages='7191--7201',
-                     month='Aug',
-                     year='2011',
-                     doi='10.1016/j.jcp.2011.05.021',
-                     feature='DPD')
+        c = cite.article(cite_key='phillips2011',
+                         author=['C L Phillips', 'J A Anderson', 'S C Glotzer'],
+                         title='Pseudo-random number generation for Brownian Dynamics and Dissipative Particle Dynamics simulations on GPU devices',
+                         journal='Journal of Computational Physics',
+                         volume=230,
+                         number=19,
+                         pages='7191--7201',
+                         month='Aug',
+                         year='2011',
+                         doi='10.1016/j.jcp.2011.05.021',
+                         feature='DPD')
+        cite._ensure_global_bib().add(c)
         
         # tell the base class how we operate
 
@@ -1975,18 +1976,19 @@ class dpd_conservative(pair):
         util.print_status_line();
 
         # register the citation
-        cite.article(cite_key='phillips2011',
-                     author=['C L Phillips', 'J A Anderson', 'S C Glotzer'],
-                     title='Pseudo-random number generation for Brownian Dynamics and Dissipative Particle Dynamics simulations on GPU devices',
-                     journal='Journal of Computational Physics',
-                     volume=230,
-                     number=19,
-                     pages='7191--7201',
-                     month='Aug',
-                     year='2011',
-                     doi='10.1016/j.jcp.2011.05.021',
-                     feature='DPD')
-                     
+        c = cite.article(cite_key='phillips2011',
+                         author=['C L Phillips', 'J A Anderson', 'S C Glotzer'],
+                         title='Pseudo-random number generation for Brownian Dynamics and Dissipative Particle Dynamics simulations on GPU devices',
+                         journal='Journal of Computational Physics',
+                         volume=230,
+                         number=19,
+                         pages='7191--7201',
+                         month='Aug',
+                         year='2011',
+                         doi='10.1016/j.jcp.2011.05.021',
+                         feature='DPD')
+        cite._ensure_global_bib().add(c)
+
         # tell the base class how we operate
 
         # initialize the base class
@@ -2047,16 +2049,17 @@ class eam(force._force):
     # eam = pair.eam(file='al1.mendelev.eam.fs', type='FS')
     # \endcode
     def __init__(self, file, type):
-        cite.article(cite_key = 'morozov2011',
-                     author=['I V Morozov','A M Kazennova','R G Bystryia','G E Normana','V V Pisareva','V V Stegailova'],
-                     title = 'Molecular dynamics simulations of the relaxation processes in the condensed matter on GPUs',
-                     journal = 'Computer Physics Communications',
-                     volume = 182,
-                     number = 9,
-                     pages = '1974--1978',
-                     year = '2011',
-                     doi = '10.1016/j.cpc.2010.12.026',
-                     feature = 'EAM')
+        c = cite.article(cite_key = 'morozov2011',
+                         author=['I V Morozov','A M Kazennova','R G Bystryia','G E Normana','V V Pisareva','V V Stegailova'],
+                         title = 'Molecular dynamics simulations of the relaxation processes in the condensed matter on GPUs',
+                         journal = 'Computer Physics Communications',
+                         volume = 182,
+                         number = 9,
+                         pages = '1974--1978',
+                         year = '2011',
+                         doi = '10.1016/j.cpc.2010.12.026',
+                         feature = 'EAM')
+        cite._ensure_global_bib().add(c)
                      
         util.print_status_line();
 
@@ -2200,17 +2203,18 @@ class dpdlj(pair):
         util.print_status_line();
         
         # register the citation
-        cite.article(cite_key='phillips2011',
-                     author=['C L Phillips', 'J A Anderson', 'S C Glotzer'],
-                     title='Pseudo-random number generation for Brownian Dynamics and Dissipative Particle Dynamics simulations on GPU devices',
-                     journal='Journal of Computational Physics',
-                     volume=230,
-                     number=19,
-                     pages='7191--7201',
-                     month='Aug',
-                     year='2011',
-                     doi='10.1016/j.jcp.2011.05.021',
-                     feature='DPD')
+        c = cite.article(cite_key='phillips2011',
+                         author=['C L Phillips', 'J A Anderson', 'S C Glotzer'],
+                         title='Pseudo-random number generation for Brownian Dynamics and Dissipative Particle Dynamics simulations on GPU devices',
+                         journal='Journal of Computational Physics',
+                         volume=230,
+                         number=19,
+                         pages='7191--7201',
+                         month='Aug',
+                         year='2011',
+                         doi='10.1016/j.jcp.2011.05.021',
+                         feature='DPD')
+        cite._ensure_global_bib().add(c)
 
         # tell the base class how we operate
 

--- a/python-module/hoomd_script/pair.py
+++ b/python-module/hoomd_script/pair.py
@@ -2047,7 +2047,7 @@ class eam(force._force):
     # eam = pair.eam(file='al1.mendelev.eam.fs', type='FS')
     # \endcode
     def __init__(self, file, type):
-        cite.article(key = 'morozov2011',
+        cite.article(cite_key = 'morozov2011',
                      author=['I V Morozov','A M Kazennova','R G Bystryia','G E Normana','V V Pisareva','V V Stegailova'],
                      title = 'Molecular dynamics simulations of the relaxation processes in the condensed matter on GPUs',
                      journal = 'Computer Physics Communications',
@@ -2056,7 +2056,7 @@ class eam(force._force):
                      pages = '1974--1978',
                      year = '2011',
                      doi = '10.1016/j.cpc.2010.12.026',
-                     url = 'http://dx.doi.org/10.1016/j.cpc.2010.12.026')
+                     feature = 'EAM')
                      
         util.print_status_line();
 

--- a/python-module/hoomd_script/pair.py
+++ b/python-module/hoomd_script/pair.py
@@ -84,6 +84,7 @@ from hoomd_script import tune;
 from hoomd_script import init;
 from hoomd_script import data;
 from hoomd_script import variant;
+from hoomd_script import cite;
 
 import math;
 import sys;
@@ -1840,7 +1841,20 @@ class dpd(pair):
     # set before it can be started with run()
     def __init__(self, r_cut, T, seed=1, name=None):
         util.print_status_line();
-
+        
+        # register the citation
+        cite.article(cite_key='phillips2011',
+                     author=['C L Phillips', 'J A Anderson', 'S C Glotzer'],
+                     title='Pseudo-random number generation for Brownian Dynamics and Dissipative Particle Dynamics simulations on GPU devices',
+                     journal='Journal of Computational Physics',
+                     volume=230,
+                     number=19,
+                     pages='7191--7201',
+                     month='Aug',
+                     year='2011',
+                     doi='10.1016/j.jcp.2011.05.021',
+                     feature='DPD')
+        
         # tell the base class how we operate
 
         # initialize the base class
@@ -1960,6 +1974,19 @@ class dpd_conservative(pair):
     def __init__(self, r_cut, name=None):
         util.print_status_line();
 
+        # register the citation
+        cite.article(cite_key='phillips2011',
+                     author=['C L Phillips', 'J A Anderson', 'S C Glotzer'],
+                     title='Pseudo-random number generation for Brownian Dynamics and Dissipative Particle Dynamics simulations on GPU devices',
+                     journal='Journal of Computational Physics',
+                     volume=230,
+                     number=19,
+                     pages='7191--7201',
+                     month='Aug',
+                     year='2011',
+                     doi='10.1016/j.jcp.2011.05.021',
+                     feature='DPD')
+                     
         # tell the base class how we operate
 
         # initialize the base class
@@ -2020,6 +2047,17 @@ class eam(force._force):
     # eam = pair.eam(file='al1.mendelev.eam.fs', type='FS')
     # \endcode
     def __init__(self, file, type):
+        cite.article(key = 'morozov2011',
+                     author=['I V Morozov','A M Kazennova','R G Bystryia','G E Normana','V V Pisareva','V V Stegailova'],
+                     title = 'Molecular dynamics simulations of the relaxation processes in the condensed matter on GPUs',
+                     journal = 'Computer Physics Communications',
+                     volume = 182,
+                     number = 9,
+                     pages = '1974--1978',
+                     year = '2011',
+                     doi = '10.1016/j.cpc.2010.12.026',
+                     url = 'http://dx.doi.org/10.1016/j.cpc.2010.12.026')
+                     
         util.print_status_line();
 
         # Error out in MPI simulations
@@ -2160,6 +2198,19 @@ class dpdlj(pair):
     # set before it can be started with run()
     def __init__(self, r_cut, T, seed=1, name=None):
         util.print_status_line();
+        
+        # register the citation
+        cite.article(cite_key='phillips2011',
+                     author=['C L Phillips', 'J A Anderson', 'S C Glotzer'],
+                     title='Pseudo-random number generation for Brownian Dynamics and Dissipative Particle Dynamics simulations on GPU devices',
+                     journal='Journal of Computational Physics',
+                     volume=230,
+                     number=19,
+                     pages='7191--7201',
+                     month='Aug',
+                     year='2011',
+                     doi='10.1016/j.jcp.2011.05.021',
+                     feature='DPD')
 
         # tell the base class how we operate
 

--- a/test/hoomd_script/test_cite.py
+++ b/test/hoomd_script/test_cite.py
@@ -1,0 +1,110 @@
+# -*- coding: iso-8859-1 -*-
+# Maintainer: mphoward
+
+from hoomd_script import *
+import unittest
+import os
+import tempfile
+
+## Automatic citation generation tests
+class cite_tests (unittest.TestCase):
+    def setUp(self):
+        print
+        init.create_empty(N=100, box=data.boxdim(L=20));
+
+        sorter.set_params(grid=8)
+        
+        # ensure that the bibliography is there
+        cite._ensure_global_bib()
+        
+        # tmp file
+        if comm.get_rank() == 0:
+            tmp = tempfile.mkstemp(suffix='.test.bib');
+            self.tmp_file = tmp[1];
+        else:
+            self.tmp_file = "invalid";
+
+    ## Test global bibliography exists and gets filled correctly with default values
+    def test_global_bib(self):
+        # global bibliography should exist after initialization
+        self.assertIsInstance(globals.bib, cite.bibliography)
+        
+        # check that it has two entries, the default HOOMD citations, and that the keys match what they should be
+        self.assertEqual(len(globals.bib.entries), 2)
+        self.assertIn('anderson2008', globals.bib.entries)
+        self.assertIn('hoomdweb', globals.bib.entries)
+
+        # stringify the global bibliography (basically, save the pointer)
+        s1 = str(globals.bib)
+
+        # add another element to the bibliography
+        c = cite.misc(cite_key='test')
+        cite._ensure_global_bib().add(c)
+        
+        # check that the global bibliography is unchanged
+        self.assertEqual(str(globals.bib), s1)
+
+        # wipeout the global bibliography and create it again
+        globals.bib = None
+        cite._ensure_global_bib()
+        self.assertIsInstance(globals.bib, cite.bibliography)
+    
+    ## Test groups of authors get names formatted properly
+    def test_format_authors(self):
+        c = cite.misc(cite_key='test')
+        
+        # no author specified should return none
+        self.assertEqual(c.format_authors(), None)
+        
+        # single author is just his name
+        c = cite.misc(cite_key='test', author='M P Howard')
+        self.assertEqual(c.format_authors(), 'M P Howard')
+        
+        # two authors looks the same whether its pretty or bibtex
+        c = cite.misc(cite_key='test', author=['M P Howard','Joshua A. Anderson'])
+        self.assertEqual(c.format_authors(), 'M P Howard and Joshua A. Anderson')
+        self.assertEqual(c.format_authors(fancy=True), 'M P Howard and Joshua A. Anderson')
+        
+        # three authors gets the oxford comma in fancy format
+        c = cite.misc(cite_key='test', author=('M P Howard', 'Joshua A. Anderson', 'Mickey Mouse'))
+        self.assertEqual(c.format_authors(), 'M P Howard and Joshua A. Anderson and Mickey Mouse')
+        self.assertEqual(c.format_authors(fancy=True), 'M P Howard, Joshua A. Anderson, and Mickey Mouse')
+    
+    ## Test display values are properly toggled on and off
+    def test_display(self):
+        c = cite.misc(cite_key='test')
+
+        # there is nothing in this string, so should return none
+        self.assertEqual(c.log(), None)
+        
+        # if display is off, it should also return none
+        c = cite.misc(cite_key='test', author='M P Howard', display=False)
+        self.assertEqual(c.log(), None)
+        
+        # if display is on, then we should get something back
+        c = cite.misc(cite_key='test', author='M P Howard')
+        self.assertNotEqual(c.log(), None)
+        self.assertNotEqual(len(c.log()), 0)
+    
+    ## Test that an error is thrown when a citation is missing a key field
+    def test_validate(self):
+        c = cite.misc(cite_key='test')
+        # override the required entries to force an error
+        c.required_entries = ['title']
+        self.assertRaises(RuntimeError, c.validate)
+    
+    ## Test that bibtex file will only overwrite when it is supposed to
+    def test_overwrite(self):
+        # the tmp file already exists, so we can only write if overwrite is enabled
+        cite.save(file=self.tmp_file,overwrite=True)
+        
+        # okay, now try to do it with overwrite disabled and make sure we get an error
+        self.assertRaises(RuntimeError, cite.save, file=self.tmp_file, overwrite=False) 
+
+    def tearDown(self):
+        init.reset();
+        if (comm.get_rank()==0):
+            os.remove(self.tmp_file);
+
+if __name__ == '__main__':
+    unittest.main(argv = ['test.py', '-v'])

--- a/test/hoomd_script/test_cite.py
+++ b/test/hoomd_script/test_cite.py
@@ -92,20 +92,6 @@ class cite_tests (unittest.TestCase):
         # override the required entries to force an error
         c.required_entries = ['title']
         self.assertRaises(RuntimeError, c.validate)
-    
-    ## Test that bibtex file will only overwrite when it is supposed to
-    def test_overwrite(self):
-        # only the root rank should attempt to save
-        if comm.get_rank() == 0:
-            # the tmp file already exists, so we can only write if overwrite is enabled
-            cite.save(file=self.tmp_file,overwrite=True,force=True)
-
-            # okay, now try to do it with overwrite disabled and make sure we get an error
-            self.assertRaises(RuntimeError, cite.save, file=self.tmp_file, overwrite=False, force=True)
-        else:
-            fname = 'invalid%d' % comm.get_rank()
-            cite.save(file=fname,overwrite=True,force=True)
-            self.assertFalse(os.path.isfile(fname))
 
     ## Test that the bibliography is automatically (or forcibly) generated as requested by the user
     def test_autosave(self):
@@ -119,56 +105,18 @@ class cite_tests (unittest.TestCase):
             self.assertEqual(nl, 0)
 
         # force a save at this immediate moment
-        cite.save(file=self.tmp_file, force=True)
+        cite.save(file=self.tmp_file)
 
         if comm.get_rank() == 0:
             nl1 = sum(1 for line in open(self.tmp_file))
             self.assertTrue(nl1 > nl)
 
-        # add a citation and request a delayed save
+        # add a citation and file should be resaved
         c = cite.misc(cite_key='test')
         cite._ensure_global_bib().add(c)
-        cite.save(file=self.tmp_file)
-
-        # this should not change the file yet
-        if comm.get_rank() == 0:
-            nl2 = sum(1 for line in open(self.tmp_file))
-            self.assertEqual(nl1, nl2)
-
-        # then, call run. shouldn't be able to save because a file already exists
-        cite.save(file=self.tmp_file, overwrite=False)
-        if comm.get_rank() == 0:
-            self.assertRaises(RuntimeError, run, 1)
-            nl2 = sum(1 for line in open(self.tmp_file))
-            self.assertEqual(nl1, nl2)
-
-        # when overwriting is turned on, run should work now
-        cite.save(file=self.tmp_file, overwrite=True)
-        run(1)
         if comm.get_rank() == 0:
             nl2 = sum(1 for line in open(self.tmp_file))
             self.assertTrue(nl2 > nl1)
-
-        # add another record
-        c2 = cite.misc(cite_key='test2')
-        cite._ensure_global_bib().add(c2)
-        cite.save(file=self.tmp_file, overwrite=False)
-        # run again, this should add the extra citation (and because we already turned saving on,
-        # it will just do it again)
-        run(1)
-        if comm.get_rank() == 0:
-            nl3 = sum(1 for line in open(self.tmp_file))
-            self.assertTrue(nl3 > nl2)
-
-        # finally, make sure that if we switch overwriting off, it still works
-        c3 = cite.misc(cite_key='test3')
-        cite._ensure_global_bib().add(c3)
-        # run again, this should add the extra citation (and because we already turned saving on,
-        # it will just do it again)
-        run(1)
-        if comm.get_rank() == 0:
-            nl4 = sum(1 for line in open(self.tmp_file))
-            self.assertTrue(nl4 > nl3)
 
     def tearDown(self):
         init.reset();


### PR DESCRIPTION
HOOMD should automatically notify the user when he uses a feature that requires citation (https://codeblue.umich.edu/hoomd-blue/doc/page_citing.html). This pull request implements this feature as a python module that creates a global bibliography. The bibliography always includes the two standard HOOMD citations, and individual features add citations on initialization. Each citation is reported to console as a level 1 notice with an optional feature descriptor, and multiple citations are grouped by feature. The user can also save the bibliography to a BibTeX file through cite.save(), which automatically updates the bibliography each time run() is called, or can optionally force a bibliography to file without calling run() (in case the user forgets to generate the file at runtime).

This pull request also addresses #42 (https://bitbucket.org/glotzer/hoomd-blue/issue/42/send-hoomd-startup-messages-through). Compilation startup messages are returned as a string, and displayed as a level 1 notice. When --notice-level=0, all non-warning/error output is suppressed.